### PR TITLE
feat(instrumentation): filter openinference spans

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,5 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - run: mise run --force setup
+      - run: mise exec -- uv pip freeze
+      - run: ls .venv/bin
       - run: mise run --force check
       - run: mise run --force test

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - run: mise check
-      - run: mise test
+      - run: mise run --force check
+      - run: mise run --force test

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -17,7 +17,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: mise run --force setup
-      - run: mise exec -- uv pip freeze
-      - run: ls .venv/bin
       - run: mise run --force check
       - run: mise run --force test

--- a/agents/community/marketing-strategy/pyproject.toml
+++ b/agents/community/marketing-strategy/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "crewai[tools]>=0.102.0,<1.0.0",
     "databricks-sdk>=0.46.0",
     "openinference-instrumentation-crewai>=0.1.7",
-    "openinference-instrumentation-langchain>=0.1.36",
 ]
 
 [project.scripts]

--- a/agents/community/marketing-strategy/src/marketing_strategy/server.py
+++ b/agents/community/marketing-strategy/src/marketing_strategy/server.py
@@ -1,7 +1,6 @@
 import json
 
 from openinference.instrumentation.crewai import CrewAIInstrumentor
-from openinference.instrumentation.langchain import LangChainInstrumentor
 from beeai_sdk.providers.agent import Server, Context
 from beeai_sdk.schemas.base import Log, LogLevel
 from crewai.agents.parser import AgentAction, AgentFinish
@@ -12,7 +11,6 @@ from marketing_strategy.crew import MarketingPostsCrew
 from beeai_sdk.schemas.text import TextInput, TextOutput
 
 CrewAIInstrumentor().instrument()
-LangChainInstrumentor().instrument()
 load_env()
 
 server = Server("crewai-agents")

--- a/agents/community/marketing-strategy/uv.lock
+++ b/agents/community/marketing-strategy/uv.lock
@@ -1483,7 +1483,6 @@ dependencies = [
     { name = "crewai", extra = ["tools"] },
     { name = "databricks-sdk" },
     { name = "openinference-instrumentation-crewai" },
-    { name = "openinference-instrumentation-langchain" },
 ]
 
 [package.metadata]
@@ -1492,7 +1491,6 @@ requires-dist = [
     { name = "crewai", extras = ["tools"], specifier = ">=0.102.0,<1.0.0" },
     { name = "databricks-sdk", specifier = ">=0.46.0" },
     { name = "openinference-instrumentation-crewai", specifier = ">=0.1.7" },
-    { name = "openinference-instrumentation-langchain", specifier = ">=0.1.36" },
 ]
 
 [[package]]
@@ -1753,23 +1751,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/b2/7c4df84d1557f5f0abdafdec3d3e53e291eaadbc5b6a6d25fba43f42809b/openinference_instrumentation_crewai-0.1.7.tar.gz", hash = "sha256:500a4d672b941d6cba4e949e879c51cfc16c85fed65ca3499c2c78fe7bd59fcd", size = 10151 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a3/14d0847c514095703237f55079235ebdd48fda2d6291b01376184f554654/openinference_instrumentation_crewai-0.1.7-py3-none-any.whl", hash = "sha256:49be2a675299753cc7d6d4c894b498a288242cc0798a47922fe7adb8b4f5b59a", size = 11660 },
-]
-
-[[package]]
-name = "openinference-instrumentation-langchain"
-version = "0.1.39"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "openinference-instrumentation" },
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/e4/0d878733441de15bcfb3ffbf7e947cb178d2bd3414e31d0e501730322957/openinference_instrumentation_langchain-0.1.39.tar.gz", hash = "sha256:8b05245d8f611d476dcf3c845c1578f45bc965691b43eb68edeb2ce80b239c6e", size = 50726 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/36/3643827b500a35a3d411cf3ba4893e0c75e248b387777a1638ae80ff4ae6/openinference_instrumentation_langchain-0.1.39-py3-none-any.whl", hash = "sha256:36a0ec21e6efc4b3fe34efc0953d9e16d79607aa612ae35874541b6182915f03", size = 18627 },
 ]
 
 [[package]]

--- a/apps/beeai-cli/tasks.toml
+++ b/apps/beeai-cli/tasks.toml
@@ -6,21 +6,21 @@ depends = ["beeai-cli:check:*"]
 ["beeai-cli:check:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-cli"
-run = "uv run ruff check --quiet"
+run = "uv run python -m ruff check --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["beeai-cli:check:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-cli"
-run = "uv run ruff format --quiet --check"
+run = "uv run python -m ruff format --quiet --check"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 # TODO: Enable and fix issues in separate PR
 # ["beeai-cli:check:pyright"]
 # dir = "{{config_root}}/apps/beeai-cli"
-# run = "uv run pyright"
+# run = "uv run python -m pyright"
 # sources = ["src/**/*.py"]
 # outputs = { auto = true }
 
@@ -32,14 +32,14 @@ depends = ["beeai-cli:fix:*"]
 ["beeai-cli:fix:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-cli"
-run = "uv run ruff check --quiet --fix"
+run = "uv run python -m ruff check --quiet --fix"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["beeai-cli:fix:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-cli"
-run = "uv run ruff format --quiet"
+run = "uv run python -m ruff format --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 

--- a/apps/beeai-server/src/beeai_server/domain/collector/base.yaml
+++ b/apps/beeai-server/src/beeai_server/domain/collector/base.yaml
@@ -20,8 +20,11 @@ processors:
   filter/phoenix:
     traces:
       span:
-        - 'resource.attributes["service.namespace"] != "beeai-agent-provider"'
-        - 'instrumentation_scope.name == "acp.shared.session" or instrumentation_scope.name == "acp"'
+        ## Filter for openinference packages
+        #### Python format `openinference.instrumentation.${package_name}`
+        #### - crewAI exception `crewai.telemetry`
+        #### Javascript format `@arizeai/openinference-instrumentation-${packageName}`
+        - not(IsMatch(instrumentation_scope.name, "^openinference\\.instrumentation\\..*") or IsMatch(instrumentation_scope.name, "^@arizeai/openinference-instrumentation-.*") or instrumentation_scope.name == "crewai.telemetry")
 
 extensions:
   health_check:

--- a/apps/beeai-server/tasks.toml
+++ b/apps/beeai-server/tasks.toml
@@ -6,14 +6,14 @@ depends = ["beeai-server:check:*"]
 ["beeai-server:check:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-server"
-run = "uv run ruff check --quiet"
+run = "uv run python -m ruff check --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["beeai-server:check:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-server"
-run = "uv run ruff format --quiet --check"
+run = "uv run python -m ruff format --quiet --check"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
@@ -21,7 +21,7 @@ outputs = { auto = true }
 # ["beeai-server:check:pyright"]
 # depends = ["setup:uv"]
 # dir = "{{config_root}}/apps/beeai-server"
-# run = "uv run pyright"
+# run = "uv run python -m pyright"
 # sources = ["src/**/*.py"]
 # outputs = { auto = true }
 
@@ -33,14 +33,14 @@ depends = ["beeai-server:fix:*"]
 ["beeai-server:fix:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-server"
-run = "uv run ruff check --quiet --fix"
+run = "uv run python -m ruff check --quiet --fix"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["beeai-server:fix:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/apps/beeai-server"
-run = "uv run ruff format --quiet"
+run = "uv run python -m ruff format --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 

--- a/mise.toml
+++ b/mise.toml
@@ -76,7 +76,7 @@ outputs = { auto = true }
 [tasks."setup:uv"]
 hide = true
 dir = "{{config_root}}"
-run = "uv sync --all-extras"
+run = "uv sync --all-extras --dev"
 sources = ["uv.lock", "pyproject.toml", "apps/*/pyproject.toml", "packages/*/pyproject.toml"]
 outputs = { auto = true }
 

--- a/packages/acp-python-sdk/tasks.toml
+++ b/packages/acp-python-sdk/tasks.toml
@@ -6,21 +6,21 @@ depends = ["acp-python-sdk:check:*"]
 ["acp-python-sdk:check:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/acp-python-sdk"
-run = "uv run ruff check --quiet"
+run = "uv run python -m ruff check --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["acp-python-sdk:check:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/acp-python-sdk"
-run = "uv run ruff format --quiet --check"
+run = "uv run python -m ruff format --quiet --check"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["acp-python-sdk:check:pyright"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/acp-python-sdk"
-run = "uv run pyright"
+run = "uv run python -m pyright"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
@@ -32,14 +32,14 @@ depends = ["acp-python-sdk:fix:*"]
 ["acp-python-sdk:fix:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/acp-python-sdk"
-run = "uv run ruff check --quiet --fix"
+run = "uv run python -m ruff check --quiet --fix"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["acp-python-sdk:fix:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/acp-python-sdk"
-run = "uv run ruff format --quiet"
+run = "uv run python -m ruff format --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
@@ -48,7 +48,7 @@ outputs = { auto = true }
 ["acp-python-sdk:test"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/acp-python-sdk"
-run = "uv run pytest"
+run = "uv run python -m pytest"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 

--- a/packages/beeai-sdk/tasks.toml
+++ b/packages/beeai-sdk/tasks.toml
@@ -6,21 +6,21 @@ depends = ["beeai-sdk:check:*"]
 ["beeai-sdk:check:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/beeai-sdk"
-run = "uv run ruff check --quiet"
+run = "uv run python -m ruff check --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["beeai-sdk:check:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/beeai-sdk"
-run = "uv run ruff format --quiet --check"
+run = "uv run python -m ruff format --quiet --check"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 # TODO: Enable and fix issues in separate PR
 # ["beeai-sdk:check:pyright"]
 # dir = "{{config_root}}/packages/beeai-sdk"
-# run = "uv run pyright"
+# run = "uv run python -m pyright"
 
 ["beeai-sdk:check:prettier"]
 depends = ["setup:pnpm"]
@@ -51,14 +51,14 @@ depends = ["beeai-sdk:fix:*"]
 ["beeai-sdk:fix:ruff-check"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/beeai-sdk"
-run = "uv run ruff check --quiet --fix"
+run = "uv run python -m ruff check --quiet --fix"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 
 ["beeai-sdk:fix:ruff-format"]
 depends = ["setup:uv"]
 dir = "{{config_root}}/packages/beeai-sdk"
-run = "uv run ruff format --quiet"
+run = "uv run python -m ruff format --quiet"
 sources = ["src/**/*.py"]
 outputs = { auto = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,4 @@ line-length = 120
 target-version = "py311"
 
 [tool.uv]
-dev-dependencies = ["pyright>=1.1.391", "pytest>=8.3.4", "ruff>=0.8.5"]
+dev-dependencies = ["pyright>=1.1.399", "pytest>=8.3.4", "ruff>=0.8.5"]

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ members = [
 
 [manifest.dependency-groups]
 dev = [
-    { name = "pyright", specifier = ">=1.1.391" },
+    { name = "pyright", specifier = ">=1.1.399" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.8.5" },
 ]
@@ -1339,15 +1339,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.394"
+version = "1.1.399"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
+sdist = { url = "https://files.pythonhosted.org/packages/db/9d/d91d5f6d26b2db95476fefc772e2b9a16d54c6bd0ea6bb5c1b6d635ab8b4/pyright-1.1.399.tar.gz", hash = "sha256:439035d707a36c3d1b443aec980bc37053fbda88158eded24b8eedcf1c7b7a1b", size = 3856954 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
+    { url = "https://files.pythonhosted.org/packages/2f/b5/380380c9e7a534cb1783c70c3e8ac6d1193c599650a55838d0557586796e/pyright-1.1.399-py3-none-any.whl", hash = "sha256:55f9a875ddf23c9698f24208c764465ffdfd38be6265f7faf9a176e1dc549f3b", size = 5592584 },
 ]
 
 [[package]]


### PR DESCRIPTION
I updated the collector filter to `- not(IsMatch(instrumentation_scope.name, "^openinference\\.instrumentation\\..*") or IsMatch(instrumentation_scope.name, "^@arizeai/openinference-instrumentation-.*") or instrumentation_scope.name == "crewai.telemetry")`. This filter should pass only spans from openiference packages.

I removed the `LangChainInstrumentor` from the crewAI `marketing-strategy` agent.
