### PR TITLE
Define env variable HOME

### DIFF
--- a/helm/beeai-platform/templates/agent/deployment.yaml
+++ b/helm/beeai-platform/templates/agent/deployment.yaml
@@ -61,6 +61,8 @@ spec:
           env:
             - name: HOST
               value: 0.0.0.0
+            - name: HOME
+              value: '/tmp'
           envFrom:
             - secretRef:
                 name: agent-variables


### PR DESCRIPTION
Define env variable HOME to /tmp'
1. To make sure container creation successful in case of strict OpenShift environment avoiding Permission denied issues like: 
           a. Permission denied: '/.mem0' 
           b. error: failed to create directory `/.cache/uv`: Permission denied (os error 13)

Signed-off-by: chandra.-potula <potula.chandureddy@gmail.com>

