### PR TITLE
feat(beeai-cli): platform image load

### DIFF
--- a/apps/beeai-cli/data/lima-vm.yaml
+++ b/apps/beeai-cli/data/lima-vm.yaml
@@ -12,7 +12,11 @@ images:
   arch: "x86_64"
 - location: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img"
   arch: "aarch64"
-mounts: []
+
+# ADDED BY BEEAI: mount configuration folder
+mounts:
+- location: "~/.beeai"
+  mountPoint: "/beeai"
 
 containerd:
   system: false

--- a/apps/beeai-server/Dockerfile
+++ b/apps/beeai-server/Dockerfile
@@ -14,19 +14,9 @@ RUN --mount=type=cache,target=/mise/downloads \
 
 FROM debian:12-slim AS runtime
 WORKDIR /app
-RUN apt-get update  &&\
-    apt-get -y --no-install-recommends install \
-    build-essential \
-    git \
-    make \
-    nodejs \
-    npm \
-    pipx \
-    python3 \
-    python3-dev \
-    &&\
+RUN apt-get update &&\
+    apt-get -y --no-install-recommends install pipx &&\
     rm -rf /var/lib/apt/lists/*
-RUN pipx install uv
 COPY --from=build /app/apps/beeai-server/dist/*.tar.gz .
 RUN pipx install ./*.tar.gz
 RUN chmod og+rx /root
@@ -35,5 +25,4 @@ ENV PATH="/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sb
     DISABLE_DOCKER=true \
     COLLECTOR_MANAGED=false \
     AGENT_REGISTRY__LOCATION="file:///app/registry.yaml"
-
 CMD ["beeai-server"]

--- a/apps/beeai-server/tasks.toml
+++ b/apps/beeai-server/tasks.toml
@@ -65,3 +65,14 @@ outputs = ["dist/**/*"]
 ["beeai-server:clean"]
 dir = "{{config_root}}/apps/beeai-server"
 run = "rm -rf ./dist"
+
+# build image
+
+["beeai-server:image-build"]
+dir = "{{config_root}}"
+run = """
+#!/bin/bash
+mkdir -p ~/.beeai/images
+docker build -t ghcr.io/i-am-bee/beeai-platform/beeai-server:local --file=apps/beeai-server/Dockerfile .
+docker save --output=$(realpath ~/.beeai/images)/beeai-server.tar ghcr.io/i-am-bee/beeai-platform/beeai-server:local
+"""


### PR DESCRIPTION
- Allow running `beeai-platform` with a locally built image (only `beeai-server` for now).
- Add more switches to `beeai platform run`: `--import-images` to load images from `~/.beeai/images`, and `--set <key>=<value>` to set Helm chart values.
- Reduce image size of `beeai-platform` from 850 MB to 150 MB (most dependencies were for bare metal providers which we don't support anymore)
- Improve docs on the development setup