### PR TITLE
Updated default model for ollama setup to granite

### DIFF
--- a/apps/beeai-cli/src/beeai_cli/commands/env.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/env.py
@@ -108,7 +108,7 @@ async def setup() -> bool:
             ),
             Choice(
                 name="IBM watsonx".ljust(25) + "🚧 experimental",
-                value=("watsonx", None, "ibm/granite-3-8b-instruct"),
+                value=("watsonx", None, "ibm/granite-3-3-8b-instruct"),
             ),
             Choice(
                 name="Ollama".ljust(25) + "💻 local", value=("Ollama", "http://localhost:11434/v1", "granite3.3:8b")

--- a/apps/beeai-cli/src/beeai_cli/commands/env.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/env.py
@@ -110,7 +110,9 @@ async def setup() -> bool:
                 name="IBM watsonx".ljust(25) + "🚧 experimental",
                 value=("watsonx", None, "ibm/granite-3-8b-instruct"),
             ),
-            Choice(name="Ollama".ljust(25) + "💻 local", value=("Ollama", "http://localhost:11434/v1", "llama3.1:8b")),
+            Choice(
+                name="Ollama".ljust(25) + "💻 local", value=("Ollama", "http://localhost:11434/v1", "granite3.2:8b")
+            ),
             Choice(name="Jan".ljust(25) + "💻 local", value=("Jan", "http://localhost:1337/v1", None)),
             Choice(name="Other (RITS, vLLM, ...)".ljust(25) + "🔧 provide API URL", value=("Other", None, None)),
         ],

--- a/apps/beeai-cli/src/beeai_cli/commands/env.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/env.py
@@ -111,7 +111,7 @@ async def setup() -> bool:
                 value=("watsonx", None, "ibm/granite-3-8b-instruct"),
             ),
             Choice(
-                name="Ollama".ljust(25) + "💻 local", value=("Ollama", "http://localhost:11434/v1", "granite3.2:8b")
+                name="Ollama".ljust(25) + "💻 local", value=("Ollama", "http://localhost:11434/v1", "granite3.3:8b")
             ),
             Choice(name="Jan".ljust(25) + "💻 local", value=("Jan", "http://localhost:1337/v1", None)),
             Choice(name="Other (RITS, vLLM, ...)".ljust(25) + "🔧 provide API URL", value=("Other", None, None)),


### PR DESCRIPTION
Small update to beeai-cli to point to granite3.2:8b during env setup with Ollama.

Closes #656 