### PR TITLE
fix(ui): suppress error toast when variables fetch fails

### DIFF
--- a/apps/beeai-ui/src/modules/runs/components/AgentModel.tsx
+++ b/apps/beeai-ui/src/modules/runs/components/AgentModel.tsx
@@ -23,7 +23,7 @@ import { isGraniteModel } from '../utils';
 import classes from './AgentModel.module.scss';
 
 export function AgentModel() {
-  const { data, isPending } = useListVariables();
+  const { data, isPending } = useListVariables({ errorToast: false, retry: false });
 
   // TEMP: Fetching the variables list will fail in production deployment,
   // so we check `isPending` and use a fallback once any response is received.

--- a/apps/beeai-ui/src/modules/variables/api/queries/useListVariables.ts
+++ b/apps/beeai-ui/src/modules/variables/api/queries/useListVariables.ts
@@ -16,13 +16,24 @@
 
 import { useQuery } from '@tanstack/react-query';
 
+import type { QueryMetadata } from '#contexts/QueryProvider/types.ts';
+
 import { listVariables } from '..';
 import { variableKeys } from '../keys';
 
-export function useListVariables() {
+interface Props {
+  errorToast?: QueryMetadata['errorToast'];
+  retry?: boolean;
+}
+
+export function useListVariables({ errorToast, retry }: Props = {}) {
   const query = useQuery({
     queryKey: variableKeys.list(),
     queryFn: listVariables,
+    retry,
+    meta: {
+      errorToast,
+    },
   });
 
   return query;


### PR DESCRIPTION
When the platform is deployed with authentication, the `/variables` endpoint fails — this is expected behavior, as it returns sensitive data (like API keys) and is intentionally restricted.

The frontend currently calls this endpoint on the agent run page to retrieve the current model via environment variables. This is only a temporary workaround until the API starts returning the model directly.

This PR hides the error toast when the fetch fails, as the failure is expected.