### PR TITLE
feat(ui): custom header nav

### DIFF
--- a/agents/official/beeai-supervisor/src/supervisor/platform-sdk.ts
+++ b/agents/official/beeai-supervisor/src/supervisor/platform-sdk.ts
@@ -13,7 +13,7 @@ export class PlatformSdk {
   private transport: SSEClientTransport;
   private client: MCPClient;
   private availableAgents?: string[];
-  private sdkUrl = new URL(`${process.env.PLATFORM_URL || "http://127.0.0.1:8333"}/mcp/sse`);
+  private sdkUrl = new URL(`${process.env.PLATFORM_URL || "http://localhost:8333"}/mcp/sse`);
 
   private constructor() {
     this.logger = Logger.root.child({ name: this.constructor.name });

--- a/apps/beeai-ui/.env.example
+++ b/apps/beeai-ui/.env.example
@@ -5,3 +5,9 @@ VITE_APP_NAME=
 
 # Default: '/bee.svg'
 VITE_APP_FAVICON_SVG=
+
+# Default: 'http://localhost:8333'
+VITE_API_SERVER_TARGET=
+
+# Default: 'http://localhost:6006'
+VITE_PHOENIX_SERVER_TARGET=

--- a/apps/beeai-ui/README.md
+++ b/apps/beeai-ui/README.md
@@ -1,1 +1,41 @@
 # BeeAI UI
+
+## Custom navigation
+
+By default, the header displays the agent's name and a detail button.
+
+You can override this with a custom navigation.
+To do so, add a `nav.json` file to the root of the project.
+Example:
+
+```json
+[
+  {
+    "label": "Playground",
+    "url": "/",
+    "isActive": true
+  },
+  {
+    "label": "Cookbooks",
+    "url": "https://example.com/cookbooks",
+    "isExternal": true
+  },
+  {
+    "label": "Docs",
+    "url": "https://example.com/docs",
+    "isExternal": true
+  },
+  {
+    "label": "Download Granite",
+    "url": "https://example.com/download-granite",
+    "isExternal": true,
+    "position": "end"
+  }
+]
+```
+
+For more details, see the [schema](./src/modules/nav/schema.ts).
+
+## ENV
+
+See [`.env.example`](./.env.example).

--- a/apps/beeai-ui/package.json
+++ b/apps/beeai-ui/package.json
@@ -11,7 +11,7 @@
     "fix": "prettier --log-level silent --write src && eslint --fix src && stylelint --fix=lax src/**/*.css src/**/*.scss",
     "preview": "vite preview",
     "clean": "rm -rf node_modules && rm -rf dist",
-    "schema:generate": "pnpm dlx openapi-typescript 'http://127.0.0.1:8333/api/v1/openapi.json' -o ./src/api/schema.d.ts --alphabetize"
+    "schema:generate": "pnpm dlx openapi-typescript 'http://localhost:8333/api/v1/openapi.json' -o ./src/api/schema.d.ts --alphabetize"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/apps/beeai-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeader.tsx
@@ -21,10 +21,12 @@ import { MainNav } from '#components/layouts/MainNav.tsx';
 import { useAgent } from '#modules/agents/api/queries/useAgent.ts';
 import type { AgentPageParams } from '#modules/agents/types.ts';
 import { getAgentDisplayName } from '#modules/agents/utils.ts';
+import { NAV } from '#utils/vite-constants.ts';
 
 import { Container } from '../layouts/Container';
 import { AgentDetailButton } from './AgentDetailButton';
 import classes from './AppHeader.module.scss';
+import { AppHeaderNav } from './AppHeaderNav';
 
 interface Props {
   className?: string;
@@ -37,12 +39,16 @@ export function AppHeader({ className }: Props) {
   return (
     <header className={clsx(classes.root, className)}>
       <Container size="full">
-        <div className={classes.holder}>
+        <div className={clsx(classes.holder, { [classes.hasNav]: NAV.length > 0 })}>
           <MainNav />
 
-          <div>{agent && <p className={classes.agentName}>{getAgentDisplayName(agent)}</p>}</div>
-
-          <div>{agent && <AgentDetailButton />}</div>
+          {NAV.length > 0 && <AppHeaderNav items={NAV} />}
+          {!NAV.length && agent && (
+            <>
+              <p className={classes.agentName}>{getAgentDisplayName(agent)}</p>
+              <AgentDetailButton />
+            </>
+          )}
         </div>
       </Container>
     </header>

--- a/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.module.scss
@@ -14,30 +14,47 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
+.nav,
+.ul,
+.link {
+  block-size: 100%;
 }
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
+.nav {
+  @include type-style(body-compact-01);
+
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  block-size: rem(56px);
-  > :last-child {
-    text-align: end;
+}
+
+.ul {
+  display: flex;
+  column-gap: rem(40px);
+}
+
+.link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  column-gap: rem(8px);
+  text-decoration: none;
+
+  &:not(:hover) {
+    --cds-link-primary: #{$black};
   }
 
-  &.hasNav {
-    grid-template-columns: auto 1fr;
+  &.active::after {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: -1px;
+    block-size: 2px;
+    background: #{$black};
   }
 }
 
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
+.icon {
+  color: #{$black};
 }

--- a/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.module.scss
@@ -41,7 +41,7 @@
   text-decoration: none;
 
   &:not(:hover) {
-    --cds-link-primary: #{$black};
+    --cds-link-primary: #{$text-dark};
   }
 
   &.active::after {
@@ -51,10 +51,10 @@
     inset-inline-end: 0;
     inset-block-end: -1px;
     block-size: 2px;
-    background: #{$black};
+    background: $text-dark;
   }
 }
 
 .icon {
-  color: #{$black};
+  color: $text-dark;
 }

--- a/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ArrowUpRight } from '@carbon/icons-react';
+import clsx from 'clsx';
+
+import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
+import type { NavItem } from '#modules/nav/schema.ts';
+
+import classes from './AppHeaderNav.module.scss';
+
+interface Props {
+  items: NavItem[];
+}
+
+export function AppHeaderNav({ items }: Props) {
+  const groups = {
+    start: items.filter((item) => item.position !== 'end'),
+    end: items.filter((item) => item.position === 'end'),
+  };
+
+  return (
+    <nav className={classes.nav}>
+      {Object.entries(groups).map(([groupKey, group]) => (
+        <ul key={groupKey} className={classes.ul}>
+          {group.map(({ label, url, isExternal, isActive }) => (
+            <li key={label}>
+              {isExternal ? (
+                <ExternalLink label={label} url={url} />
+              ) : (
+                <InternalLink label={label} url={url} isActive={isActive} />
+              )}
+            </li>
+          ))}
+        </ul>
+      ))}
+    </nav>
+  );
+}
+
+interface LinkProps {
+  label: string;
+  url: string;
+  isActive?: boolean;
+}
+
+const ExternalLink = ({ label, url }: LinkProps) => (
+  <a href={url} className={classes.link} target="_blank" rel="noreferrer">
+    {label}
+    <ArrowUpRight className={classes.icon} />
+  </a>
+);
+
+const InternalLink = ({ label, url, isActive }: LinkProps) => (
+  <TransitionLink href={url} className={clsx(classes.link, { [classes.active]: isActive })}>
+    {label}
+  </TransitionLink>
+);

--- a/apps/beeai-ui/src/modules/nav/parseNav.ts
+++ b/apps/beeai-ui/src/modules/nav/parseNav.ts
@@ -14,30 +14,9 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
+import { type NavItem, navSchema } from './schema';
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  > :last-child {
-    text-align: end;
-  }
-
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
-
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
+export function parseNav(data: unknown): NavItem[] {
+  const result = navSchema.safeParse(data);
+  return result.success ? result.data : [];
 }

--- a/apps/beeai-ui/src/modules/nav/schema.ts
+++ b/apps/beeai-ui/src/modules/nav/schema.ts
@@ -14,30 +14,16 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
+import { z } from 'zod';
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  > :last-child {
-    text-align: end;
-  }
+const navItemSchema = z.object({
+  label: z.string(),
+  url: z.union([z.string().url(), z.literal('/')]),
+  isActive: z.boolean().optional(),
+  isExternal: z.boolean().optional(),
+  position: z.enum(['start', 'end']).optional(),
+});
 
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
+export const navSchema = z.array(navItemSchema);
 
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
-}
+export type NavItem = z.infer<typeof navItemSchema>;

--- a/apps/beeai-ui/src/utils/files/loadFile.ts
+++ b/apps/beeai-ui/src/utils/files/loadFile.ts
@@ -15,24 +15,26 @@
  */
 
 import { promises as fs } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Loads and parses a JSON file relative to the calling module.
- * Returns undefined if the file is missing or contains invalid JSON.
+ * Loads a file relative to the calling module.
+ * - Parses `.json` files as JSON
+ * - Returns string content for all other file types
+ * Returns `undefined` on read or parse failure.
  *
  * @param relativeTo - Typically `import.meta.url` from the caller module
- * @param filename - The JSON file name to load (e.g. 'nav.json')
- * @returns Parsed JSON object, or `undefined` if loading/parsing fails
+ * @param filename - File name to load (e.g. 'nav.json' or 'README.md')
+ * @returns Parsed object (for JSON) or raw string (for text), or `undefined` on failure
  */
-export async function loadJson(relativeTo: string, filename: string) {
+export async function loadFile(relativeTo: string, filename: string): Promise<unknown | string | undefined> {
   const dir = dirname(fileURLToPath(relativeTo));
   const fullPath = join(dir, filename);
 
   try {
     const content = await fs.readFile(fullPath, 'utf8');
-    return JSON.parse(content);
+    return extname(filename) === '.json' ? JSON.parse(content) : content;
   } catch {
     return undefined;
   }

--- a/apps/beeai-ui/src/utils/files/loadJson.ts
+++ b/apps/beeai-ui/src/utils/files/loadJson.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { pathToFileURL } from 'node:url';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Dynamically loads a JSON file relative to the caller module.
- * Works in ESM environments using import assertions.
+ * Loads and parses a JSON file relative to the calling module.
+ * Returns undefined if the file is missing or contains invalid JSON.
  *
  * @param relativeTo - Typically `import.meta.url` from the caller module
  * @param filename - The JSON file name to load (e.g. 'nav.json')
@@ -29,13 +29,10 @@ import { fileURLToPath } from 'node:url';
 export async function loadJson(relativeTo: string, filename: string) {
   const dir = dirname(fileURLToPath(relativeTo));
   const fullPath = join(dir, filename);
-  const filePath = pathToFileURL(fullPath).href;
 
   try {
-    const module = await import(filePath, {
-      with: { type: 'json' },
-    });
-    return module.default;
+    const content = await fs.readFile(fullPath, 'utf8');
+    return JSON.parse(content);
   } catch {
     return undefined;
   }

--- a/apps/beeai-ui/src/utils/modules/loadJson.ts
+++ b/apps/beeai-ui/src/utils/modules/loadJson.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Dynamically loads a JSON file relative to the caller module.
+ * Works in ESM environments using import assertions.
+ *
+ * @param relativeTo - Typically `import.meta.url` from the caller module
+ * @param filename - The JSON file name to load (e.g. 'nav.json')
+ * @returns Parsed JSON object, or `undefined` if loading/parsing fails
+ */
+export async function loadJson(relativeTo: string, filename: string) {
+  const dir = dirname(fileURLToPath(relativeTo));
+  const fullPath = join(dir, filename);
+  const filePath = pathToFileURL(fullPath).href;
+
+  try {
+    const module = await import(filePath, {
+      with: { type: 'json' },
+    });
+    return module.default;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/beeai-ui/src/utils/vite-constants.ts
+++ b/apps/beeai-ui/src/utils/vite-constants.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+import { parseNav } from '#modules/nav/parseNav.ts';
+
 export const APP_NAME = __APP_NAME__;
+
+export const NAV = parseNav(__NAV__);
 
 export const PHOENIX_SERVER_TARGET = __PHOENIX_SERVER_TARGET__;
 

--- a/apps/beeai-ui/src/vite-env.d.ts
+++ b/apps/beeai-ui/src/vite-env.d.ts
@@ -18,4 +18,5 @@
 /// <reference types="vite/client" />
 
 declare const __APP_NAME__: string;
+declare const __NAV__: object;
 declare const __PHOENIX_SERVER_TARGET__: string;

--- a/apps/beeai-ui/vite.config.ts
+++ b/apps/beeai-ui/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react-swc';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
-import { loadJson } from './src/utils/modules/loadJson';
+import { loadJson } from './src/utils/files/loadJson';
 
 const DEFAULT_ENV = {
   VITE_APP_NAME: 'BeeAI',

--- a/apps/beeai-ui/vite.config.ts
+++ b/apps/beeai-ui/vite.config.ts
@@ -5,29 +5,27 @@ import react from '@vitejs/plugin-react-swc';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
+import { loadJson } from './src/utils/modules/loadJson';
+
 const DEFAULT_ENV = {
   VITE_APP_NAME: 'BeeAI',
   VITE_APP_FAVICON_SVG: '/bee.svg',
-  API_SERVER_TARGET: 'http://127.0.0.1:8333',
-  PHOENIX_SERVER_TARGET: 'http://localhost:6006',
+  VITE_API_SERVER_TARGET: 'http://localhost:8333',
+  VITE_PHOENIX_SERVER_TARGET: 'http://localhost:6006',
 } as const;
 
-export default defineConfig(({ mode }): UserConfig => {
-  const {
-    VITE_APP_NAME,
-    VITE_APP_FAVICON_SVG,
-    API_SERVER_TARGET,
-    PHOENIX_SERVER_TARGET,
-  } = { ...DEFAULT_ENV, ...loadEnv(mode, process.cwd()) };
+export default defineConfig(async ({ mode }): Promise<UserConfig> => {
+  const { VITE_APP_NAME, VITE_APP_FAVICON_SVG, VITE_API_SERVER_TARGET, VITE_PHOENIX_SERVER_TARGET } = {
+    ...DEFAULT_ENV,
+    ...loadEnv(mode, process.cwd()),
+  };
 
   return {
     plugins: [
       {
         name: 'constants',
         transformIndexHtml(html) {
-          return html
-            .replace(/%__APP_NAME__%/g, VITE_APP_NAME)
-            .replace(/%__APP_FAVICON_SVG__%/g, VITE_APP_FAVICON_SVG);
+          return html.replace(/%__APP_NAME__%/g, VITE_APP_NAME).replace(/%__APP_FAVICON_SVG__%/g, VITE_APP_FAVICON_SVG);
         },
       },
       react(),
@@ -37,15 +35,17 @@ export default defineConfig(({ mode }): UserConfig => {
     ],
     define: {
       __APP_NAME__: JSON.stringify(VITE_APP_NAME),
-      __PHOENIX_SERVER_TARGET__: JSON.stringify(PHOENIX_SERVER_TARGET),
+      __NAV__: await loadJson(import.meta.url, 'nav.json'),
+      __PHOENIX_SERVER_TARGET__: JSON.stringify(VITE_PHOENIX_SERVER_TARGET),
     },
     server: {
       proxy: {
         '/api': {
-          target: API_SERVER_TARGET,
+          target: VITE_API_SERVER_TARGET,
+          changeOrigin: true,
         },
         '/phoenix': {
-          target: PHOENIX_SERVER_TARGET,
+          target: VITE_PHOENIX_SERVER_TARGET,
         },
       },
     },

--- a/apps/beeai-ui/vite.config.ts
+++ b/apps/beeai-ui/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react-swc';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
-import { loadJson } from './src/utils/files/loadJson';
+import { loadFile } from './src/utils/files/loadFile';
 
 const DEFAULT_ENV = {
   VITE_APP_NAME: 'BeeAI',
@@ -35,7 +35,7 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
     ],
     define: {
       __APP_NAME__: JSON.stringify(VITE_APP_NAME),
-      __NAV__: await loadJson(import.meta.url, 'nav.json'),
+      __NAV__: await loadFile(import.meta.url, 'nav.json'),
       __PHOENIX_SERVER_TARGET__: JSON.stringify(VITE_PHOENIX_SERVER_TARGET),
     },
     server: {


### PR DESCRIPTION
## Custom navigation

Allow for **custom navigation** in the header by adding a `nav.json` file to the root of the UI project.
The file is <ins>optional</ins>. If _omitted_ or _invalid_, standard header is used (which displays the agent's name and a detail button).

### Example `nav.json`

```json
[
  {
    "label": "Playground",
    "url": "/",
    "isActive": true
  },
  {
    "label": "Cookbooks",
    "url": "https://example.com/cookbooks",
    "isExternal": true
  },
  {
    "label": "Docs",
    "url": "https://example.com/docs",
    "isExternal": true
  },
  {
    "label": "Download Granite",
    "url": "https://example.com/download-granite",
    "isExternal": true,
    "position": "end"
  }
]
```

### Preview

![preview](https://github.com/user-attachments/assets/97e6a347-8970-49e8-85ee-69175ef7d6d9)

<br><br>

---

### Other changes
- Prefix envs with `VITE_` (so can customize `VITE_API_SERVER_TARGET` via `loadEnv()`)
- Allow for custom `VITE_API_SERVER_TARGET`
- Use `localhost`
- Update `.env.example`
