### PR TITLE
feat: added sidebar variant

### DIFF
--- a/apps/beeai-ui/.env.example
+++ b/apps/beeai-ui/.env.example
@@ -6,6 +6,9 @@ VITE_APP_NAME=
 # Default: '/bee.svg'
 VITE_APP_FAVICON_SVG=
 
+# Default: 'toggle-in-header'
+VITE_APP_SIDEBAR_VARIANT=
+
 # Default: 'http://localhost:8333'
 VITE_API_SERVER_TARGET=
 

--- a/apps/beeai-ui/README.md
+++ b/apps/beeai-ui/README.md
@@ -36,6 +36,17 @@ Example:
 
 For more details, see the [schema](./src/modules/nav/schema.ts).
 
+
 ## ENV
 
 See [`.env.example`](./.env.example).
+
+
+## Sidebar toggle position
+
+By default, the hamburger menu used to toggle the sidebar is located in the header.
+Its position can be configured using `VITE_APP_SIDEBAR_VARIANT` variable in `.env` file.
+
+Two options are currently supported.
+- `toggle-in-header` (default): Displays the hamburger menu inside the header, next to the app name.
+- `toggle-below-header`: Displays the hamburger menu below the header with the agent name. The new session button appears next to the menu.

--- a/apps/beeai-ui/src/components/AgentsNav/AgentsNav.module.scss
+++ b/apps/beeai-ui/src/components/AgentsNav/AgentsNav.module.scss
@@ -20,6 +20,15 @@
   row-gap: $spacing-04;
   padding-inline: $spacing-05;
   @include scrollbar();
+
+  &.toggleBelowHeader {
+    padding-block-start: rem(48px);
+
+    .heading {
+      border-block-start: rem(1px) solid $border-subtle-00;
+      padding-block-start: rem(16px);
+    }
+  }
 }
 
 .heading {
@@ -52,14 +61,5 @@
 
   &.isActive {
     background-color: $layer-02;
-  }
-}
-
-.root.toggleBelowHeader {
-  padding-block-start: rem(48px);
-
-  .heading {
-    border-block-start: rem(1px) solid $border-subtle-00;
-    padding-block-start: rem(16px);
   }
 }

--- a/apps/beeai-ui/src/components/AgentsNav/AgentsNav.module.scss
+++ b/apps/beeai-ui/src/components/AgentsNav/AgentsNav.module.scss
@@ -54,3 +54,12 @@
     background-color: $layer-02;
   }
 }
+
+.root.toggleBelowHeader {
+  padding-block-start: rem(48px);
+
+  .heading {
+    border-block-start: rem(1px) solid $border-subtle-00;
+    padding-block-start: rem(16px);
+  }
+}

--- a/apps/beeai-ui/src/components/AgentsNav/AgentsNav.tsx
+++ b/apps/beeai-ui/src/components/AgentsNav/AgentsNav.tsx
@@ -26,7 +26,11 @@ import { routes } from '#utils/router.ts';
 
 import classes from './AgentsNav.module.scss';
 
-export function AgentsNav() {
+interface Props {
+  toggleBelowHeader?: boolean;
+}
+
+export function AgentsNav({ toggleBelowHeader }: Props) {
   const { pathname } = useLocation();
   const { transitionTo } = useViewTransition();
 
@@ -34,8 +38,8 @@ export function AgentsNav() {
   const agents = data?.filter(isAgentUiSupported).sort(sortAgentsByName);
 
   return (
-    <nav className={classes.root}>
-      <h2 className={classes.heading}>Agents</h2>
+    <nav className={clsx(classes.root, toggleBelowHeader && classes.toggleBelowHeader)}>
+      <h2 className={classes.heading}>{toggleBelowHeader ? 'Try an Agent' : 'Agents'}</h2>
 
       <ul className={classes.list}>
         {!isPending ? (

--- a/apps/beeai-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeader.tsx
@@ -21,12 +21,14 @@ import { MainNav } from '#components/layouts/MainNav.tsx';
 import { useAgent } from '#modules/agents/api/queries/useAgent.ts';
 import type { AgentPageParams } from '#modules/agents/types.ts';
 import { getAgentDisplayName } from '#modules/agents/utils.ts';
-import { APP_NAME, NAV, SIDEBAR_VARIANT } from '#utils/vite-constants.ts';
+import { isSidebarToggleBelowHeader } from '#modules/sidebar/isSidebarToggleBelowHeader.ts';
+import { NAV } from '#utils/vite-constants.ts';
 
 import { Container } from '../layouts/Container';
 import { AgentDetailButton } from './AgentDetailButton';
 import classes from './AppHeader.module.scss';
 import { AppHeaderNav } from './AppHeaderNav';
+import { AppName } from './AppName';
 
 interface Props {
   className?: string;
@@ -35,13 +37,13 @@ interface Props {
 export function AppHeader({ className }: Props) {
   const { agentName } = useParams<AgentPageParams>();
   const { data: agent } = useAgent({ name: agentName ?? '' });
-  const toggleBelowHeader = SIDEBAR_VARIANT === 'toggle-below-header';
+  const toggleBelowHeader = isSidebarToggleBelowHeader();
 
   return (
     <header className={clsx(classes.root, className)}>
       <Container size="full">
         <div className={clsx(classes.holder, { [classes.hasNav]: NAV.length > 0 })}>
-          {toggleBelowHeader && agent ? <span className={classes.appName}>{APP_NAME}</span> : <MainNav />}
+          {toggleBelowHeader && agent ? <AppName /> : <MainNav />}
 
           {NAV.length > 0 && <AppHeaderNav items={NAV} />}
           {!NAV.length && agent && (

--- a/apps/beeai-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeader.tsx
@@ -21,7 +21,7 @@ import { MainNav } from '#components/layouts/MainNav.tsx';
 import { useAgent } from '#modules/agents/api/queries/useAgent.ts';
 import type { AgentPageParams } from '#modules/agents/types.ts';
 import { getAgentDisplayName } from '#modules/agents/utils.ts';
-import { NAV } from '#utils/vite-constants.ts';
+import { APP_NAME, NAV, SIDEBAR_VARIANT } from '#utils/vite-constants.ts';
 
 import { Container } from '../layouts/Container';
 import { AgentDetailButton } from './AgentDetailButton';
@@ -35,18 +35,21 @@ interface Props {
 export function AppHeader({ className }: Props) {
   const { agentName } = useParams<AgentPageParams>();
   const { data: agent } = useAgent({ name: agentName ?? '' });
+  const toggleBelowHeader = SIDEBAR_VARIANT === 'toggle-below-header';
 
   return (
     <header className={clsx(classes.root, className)}>
       <Container size="full">
         <div className={clsx(classes.holder, { [classes.hasNav]: NAV.length > 0 })}>
-          <MainNav />
+          {toggleBelowHeader && agent ? <span className={classes.appName}>{APP_NAME}</span> : <MainNav />}
 
           {NAV.length > 0 && <AppHeaderNav items={NAV} />}
           {!NAV.length && agent && (
             <>
               <p className={classes.agentName}>{getAgentDisplayName(agent)}</p>
-              <AgentDetailButton />
+              <div className={classes.alignEnd}>
+                <AgentDetailButton />
+              </div>
             </>
           )}
         </div>

--- a/apps/beeai-ui/src/components/AppHeader/AppName.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/AppName.module.scss
@@ -14,30 +14,9 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
-
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  .alignEnd {
-    text-align: end;
-  }
-
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
-
-.agentName {
+.appName {
   font-size: rem(14px);
-  line-height: math.div(20, 14);
+  line-height: math.div(18, 14);
+  font-weight: 600;
+  color: $text-dark;
 }

--- a/apps/beeai-ui/src/components/AppHeader/AppName.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppName.tsx
@@ -14,30 +14,10 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
+import { APP_NAME } from '#utils/vite-constants.ts';
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  .alignEnd {
-    text-align: end;
-  }
+import classes from './AppName.module.scss';
 
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
-
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
+export function AppName() {
+  return <span className={classes.appName}>{APP_NAME}</span>;
 }

--- a/apps/beeai-ui/src/components/AppHeader/SidebarButton.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/SidebarButton.module.scss
@@ -33,3 +33,28 @@
   font-weight: 600;
   color: $text-dark;
 }
+
+.root.belowHeader {
+  position: relative;
+  z-index: 2;
+  margin-inline-start: 0;
+
+  button {
+    padding: rem(6px);
+    block-size: rem(32px);
+    background: $background;
+
+    &.selected {
+      background: $layer-accent-01;
+    }
+
+    &:not(.selected) {
+      padding-inline-start: rem(32px);
+    }
+
+    svg {
+      inset-block-start: rem(7px);
+      inset-inline-start: rem(8px);
+    }
+  }
+}

--- a/apps/beeai-ui/src/components/AppHeader/SidebarButton.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/SidebarButton.module.scss
@@ -19,42 +19,35 @@
   align-items: center;
   column-gap: $spacing-03;
   margin-inline-start: -$spacing-03;
+
+  &.wAgentName {
+    position: relative;
+    z-index: 2;
+    margin-inline-start: 0;
+
+    button {
+      padding: rem(6px);
+      block-size: rem(32px);
+      background: $background;
+
+      &.selected {
+        background: $layer-accent-01;
+      }
+
+      &:not(.selected) {
+        padding-inline-start: rem(32px);
+      }
+
+      svg {
+        inset-block-start: rem(7px);
+        inset-inline-start: rem(8px);
+      }
+    }
+  }
 }
 
 .button {
   :global(.cds--popover) {
     display: none;
-  }
-}
-
-.label {
-  font-size: rem(14px);
-  line-height: math.div(18, 14);
-  font-weight: 600;
-  color: $text-dark;
-}
-
-.root.belowHeader {
-  position: relative;
-  z-index: 2;
-  margin-inline-start: 0;
-
-  button {
-    padding: rem(6px);
-    block-size: rem(32px);
-    background: $background;
-
-    &.selected {
-      background: $layer-accent-01;
-    }
-
-    &:not(.selected) {
-      padding-inline-start: rem(32px);
-    }
-
-    svg {
-      inset-block-start: rem(7px);
-      inset-inline-start: rem(8px);
-    }
   }
 }

--- a/apps/beeai-ui/src/components/AppHeader/SidebarButton.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/SidebarButton.tsx
@@ -15,9 +15,14 @@
  */
 
 import { Menu } from '@carbon/icons-react';
-import { IconButton } from '@carbon/react';
+import { Button, IconButton } from '@carbon/react';
+import clsx from 'clsx';
+import { useParams } from 'react-router';
 
 import { useApp } from '#contexts/App/index.ts';
+import { useAgent } from '#modules/agents/api/queries/useAgent.ts';
+import type { AgentPageParams } from '#modules/agents/types.ts';
+import { getAgentDisplayName } from '#modules/agents/utils.ts';
 import { APP_NAME } from '#utils/vite-constants.ts';
 
 import classes from './SidebarButton.module.scss';
@@ -40,5 +45,31 @@ export function SidebarButton() {
 
       <span className={classes.label}>{APP_NAME}</span>
     </div>
+  );
+}
+
+export function SidebarButtonWAgentName() {
+  const { agentName } = useParams<AgentPageParams>();
+  const { data: agent } = useAgent({ name: agentName ?? '' });
+  const { setNavigationOpen, navigationOpen } = useApp();
+
+  return agent ? (
+    <div className={clsx(classes.root, classes.belowHeader)}>
+      <div className={classes.button}>
+        <Button
+          kind={navigationOpen ? 'ghost' : 'tertiary'}
+          size="sm"
+          renderIcon={Menu}
+          hasIconOnly={navigationOpen}
+          className={clsx(navigationOpen && classes.selected)}
+          onClick={() => setNavigationOpen?.((value) => !value)}
+          iconDescription="Toggle sidebar"
+        >
+          {getAgentDisplayName(agent)}
+        </Button>
+      </div>
+    </div>
+  ) : (
+    <SidebarButton />
   );
 }

--- a/apps/beeai-ui/src/components/AppHeader/SidebarButton.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/SidebarButton.tsx
@@ -23,8 +23,8 @@ import { useApp } from '#contexts/App/index.ts';
 import { useAgent } from '#modules/agents/api/queries/useAgent.ts';
 import type { AgentPageParams } from '#modules/agents/types.ts';
 import { getAgentDisplayName } from '#modules/agents/utils.ts';
-import { APP_NAME } from '#utils/vite-constants.ts';
 
+import { AppName } from './AppName';
 import classes from './SidebarButton.module.scss';
 
 export function SidebarButton() {
@@ -43,7 +43,7 @@ export function SidebarButton() {
         <Menu />
       </IconButton>
 
-      <span className={classes.label}>{APP_NAME}</span>
+      <AppName />
     </div>
   );
 }
@@ -54,7 +54,7 @@ export function SidebarButtonWAgentName() {
   const { setNavigationOpen, navigationOpen } = useApp();
 
   return agent ? (
-    <div className={clsx(classes.root, classes.belowHeader)}>
+    <div className={clsx(classes.root, classes.wAgentName)}>
       <div className={classes.button}>
         <Button
           kind={navigationOpen ? 'ghost' : 'tertiary'}

--- a/apps/beeai-ui/src/components/layouts/MainNav.tsx
+++ b/apps/beeai-ui/src/components/layouts/MainNav.tsx
@@ -18,7 +18,7 @@ import { type RefObject, useRef } from 'react';
 import { useOnClickOutside } from 'usehooks-ts';
 
 import { AgentsNav } from '#components/AgentsNav/AgentsNav.tsx';
-import { SidebarButton } from '#components/AppHeader/SidebarButton.tsx';
+import { SidebarButton, SidebarButtonWAgentName } from '#components/AppHeader/SidebarButton.tsx';
 import { SidePanel } from '#components/SidePanel/SidePanel.tsx';
 import { UserNav } from '#components/UserNav/UserNav.tsx';
 import { useApp } from '#contexts/App/index.ts';
@@ -26,7 +26,11 @@ import { useAppConfig } from '#contexts/AppConfig/index.ts';
 
 import classes from './MainNav.module.scss';
 
-export function MainNav() {
+interface Props {
+  toggleBelowHeader?: boolean;
+}
+
+export function MainNav({ toggleBelowHeader }: Props) {
   const { navigationOpen } = useApp();
   const { featureFlags } = useAppConfig();
   const { closeNavOnClickOutside, setNavigationOpen } = useApp();
@@ -40,11 +44,11 @@ export function MainNav() {
 
   return (
     <div ref={navRef}>
-      <SidebarButton />
+      {toggleBelowHeader ? <SidebarButtonWAgentName /> : <SidebarButton />}
 
       <SidePanel variant="left" isOpen={navigationOpen}>
         <div className={classes.root}>
-          <AgentsNav />
+          <AgentsNav toggleBelowHeader={toggleBelowHeader} />
 
           {featureFlags?.user_navigation && (
             <div className={classes.footer}>

--- a/apps/beeai-ui/src/modules/runs/chat/Chat.module.scss
+++ b/apps/beeai-ui/src/modules/runs/chat/Chat.module.scss
@@ -26,7 +26,10 @@
 .holder {
   display: grid;
   grid-template-rows: max-content 1fr max-content;
-  row-gap: $spacing-06;
+
+  > *:not(:last-child) {
+    margin-block-end: $spacing-06;
+  }
 }
 
 .header {

--- a/apps/beeai-ui/src/modules/runs/chat/Chat.tsx
+++ b/apps/beeai-ui/src/modules/runs/chat/Chat.tsx
@@ -79,14 +79,13 @@ export function Chat() {
   return (
     <div className={clsx(classes.root, { [classes.isNew]: isNew })}>
       <Container size="sm" className={classes.holder}>
-        {isNew ? (
+        {isNew && (
           <div className={classes.header}>
             <AgentIcon size="xl" />
             <AgentGreeting agent={agent} />
           </div>
-        ) : (
-          <AgentHeader className={classes.header} onNewSessionClick={onClear} />
         )}
+        <AgentHeader className={classes.header} onNewSessionClick={onClear} hideButton={isNew} />
 
         {!isNew && (
           <div className={classes.content} ref={scrollRef}>

--- a/apps/beeai-ui/src/modules/runs/components/AgentHeader.module.scss
+++ b/apps/beeai-ui/src/modules/runs/components/AgentHeader.module.scss
@@ -35,3 +35,11 @@
 .name {
   @include line-clamp();
 }
+
+div#fixedRoot {
+  margin-block-end: 0;
+
+  &.spacing {
+    block-size: 1.5rem;
+  }
+}

--- a/apps/beeai-ui/src/modules/runs/components/AgentHeader.tsx
+++ b/apps/beeai-ui/src/modules/runs/components/AgentHeader.tsx
@@ -14,23 +14,35 @@
  * limitations under the License.
  */
 
-import { IconButton } from '@carbon/react';
 import clsx from 'clsx';
 
 import type { Agent } from '#modules/agents/api/types.ts';
 import { getAgentDisplayName } from '#modules/agents/utils.ts';
+import { SIDEBAR_VARIANT } from '#utils/vite-constants.ts';
 
 import { AgentIcon } from '../components/AgentIcon';
 import classes from './AgentHeader.module.scss';
-import NewSession from './NewSession.svg';
+import { NewSessionButton } from './NewSessionButtton';
 
 interface Props {
   agent?: Agent;
   onNewSessionClick?: () => void;
   className?: string;
+  hideButton?: boolean;
 }
 
-export function AgentHeader({ agent, onNewSessionClick, className }: Props) {
+export function AgentHeader({ agent, onNewSessionClick, className, hideButton }: Props) {
+  const sidebarToggleBelowHeader = SIDEBAR_VARIANT === 'toggle-below-header';
+
+  if (sidebarToggleBelowHeader)
+    return (
+      <div className={clsx(agent && classes.spacing)} id={classes.fixedRoot}>
+        {onNewSessionClick && <NewSessionButton onNewSessionClick={onNewSessionClick} fixed />}
+      </div>
+    );
+
+  if (!agent && hideButton) return null;
+
   return (
     <header className={clsx(classes.root, className)}>
       <div>
@@ -43,11 +55,7 @@ export function AgentHeader({ agent, onNewSessionClick, className }: Props) {
         )}
       </div>
 
-      {onNewSessionClick && (
-        <IconButton kind="tertiary" size="sm" label="New session" align="left" autoAlign onClick={onNewSessionClick}>
-          <NewSession />
-        </IconButton>
-      )}
+      {!hideButton && onNewSessionClick && <NewSessionButton onNewSessionClick={onNewSessionClick} />}
     </header>
   );
 }

--- a/apps/beeai-ui/src/modules/runs/components/AgentHeader.tsx
+++ b/apps/beeai-ui/src/modules/runs/components/AgentHeader.tsx
@@ -18,7 +18,7 @@ import clsx from 'clsx';
 
 import type { Agent } from '#modules/agents/api/types.ts';
 import { getAgentDisplayName } from '#modules/agents/utils.ts';
-import { SIDEBAR_VARIANT } from '#utils/vite-constants.ts';
+import { isSidebarToggleBelowHeader } from '#modules/sidebar/isSidebarToggleBelowHeader.ts';
 
 import { AgentIcon } from '../components/AgentIcon';
 import classes from './AgentHeader.module.scss';
@@ -32,7 +32,7 @@ interface Props {
 }
 
 export function AgentHeader({ agent, onNewSessionClick, className, hideButton }: Props) {
-  const sidebarToggleBelowHeader = SIDEBAR_VARIANT === 'toggle-below-header';
+  const sidebarToggleBelowHeader = isSidebarToggleBelowHeader();
 
   if (sidebarToggleBelowHeader)
     return (

--- a/apps/beeai-ui/src/modules/runs/components/NewSessionButton.module.scss
+++ b/apps/beeai-ui/src/modules/runs/components/NewSessionButton.module.scss
@@ -14,37 +14,28 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
+.fixed {
+  position: fixed;
+  inset-block-start: rem(80px);
+  inset-inline-start: 0;
+  padding-inline: $spacing-05;
+  display: flex;
+  justify-content: flex-start;
+  column-gap: rem(8px);
   z-index: 1;
 }
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  .alignEnd {
-    text-align: end;
-  }
-
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
+.navOpen.fixed {
+  inline-size: 100%;
+  max-inline-size: rem(272px);
+  justify-content: space-between;
 }
 
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
-}
+.button {
+  position: relative;
+  z-index: 2;
 
-.appName {
-  font-size: rem(14px);
-  line-height: math.div(18, 14);
-  font-weight: 600;
-  color: $text-dark;
+  button {
+    background-color: $background;
+  }
 }

--- a/apps/beeai-ui/src/modules/runs/components/NewSessionButtton.tsx
+++ b/apps/beeai-ui/src/modules/runs/components/NewSessionButtton.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IconButton } from '@carbon/react';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+import type { PropsWithChildren } from 'react';
+import { createPortal } from 'react-dom';
+
+import { MainNav } from '#components/layouts/MainNav.tsx';
+import { useApp } from '#contexts/App/index.ts';
+
+import NewSession from './NewSession.svg';
+import classes from './NewSessionButton.module.scss';
+
+interface Props {
+  onNewSessionClick?: () => void;
+  fixed?: boolean;
+}
+
+export function NewSessionButton({ onNewSessionClick, fixed }: Props) {
+  if (!onNewSessionClick) return null;
+
+  const Button = (
+    <IconButton
+      kind="tertiary"
+      size="sm"
+      label="New session"
+      align={fixed ? 'right' : 'left'}
+      autoAlign
+      onClick={onNewSessionClick}
+      wrapperClasses={classes.button}
+    >
+      <NewSession />
+    </IconButton>
+  );
+
+  if (fixed) return <FixedButton>{Button}</FixedButton>;
+
+  return Button;
+}
+
+function FixedButton({ children }: PropsWithChildren) {
+  const { navigationOpen } = useApp();
+  if (!(window && document)) return null;
+  return createPortal(
+    <div className={clsx(classes.fixed, navigationOpen && classes.navOpen)}>
+      <MainNav toggleBelowHeader />
+      <motion.div layout="position" transition={{ duration: 0.24 }}>
+        {children}
+      </motion.div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/beeai-ui/src/modules/runs/hands-off/HandsOff.tsx
+++ b/apps/beeai-ui/src/modules/runs/hands-off/HandsOff.tsx
@@ -38,7 +38,7 @@ export function HandsOff() {
       <div className={clsx(classes.root, { [classes.isPendingOrOutput]: isPendingOrOutput })}>
         <div className={classes.holder}>
           <div className={classes.header}>
-            <AgentHeader agent={agent} onNewSessionClick={isPendingOrOutput ? onClear : undefined} />
+            <AgentHeader agent={agent} onNewSessionClick={onClear} hideButton={!isPendingOrOutput} />
 
             {isCompleted ? (
               <h2 className={classes.heading}>Task input:</h2>

--- a/apps/beeai-ui/src/modules/sidebar/isSidebarToggleBelowHeader.ts
+++ b/apps/beeai-ui/src/modules/sidebar/isSidebarToggleBelowHeader.ts
@@ -14,30 +14,10 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
+import { SIDEBAR_VARIANT } from '#utils/vite-constants.ts';
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  .alignEnd {
-    text-align: end;
-  }
+import { SidebarVariantEnum } from './schema';
 
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
-
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
+export function isSidebarToggleBelowHeader() {
+  return SIDEBAR_VARIANT === SidebarVariantEnum.TOGGLE_BELOW_HEADER;
 }

--- a/apps/beeai-ui/src/modules/sidebar/parseSiebarVariant.ts
+++ b/apps/beeai-ui/src/modules/sidebar/parseSiebarVariant.ts
@@ -14,30 +14,9 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
+import { type SidebarVariant, SidebarVariantEnum, sidebarVariantSchema } from './schema';
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  .alignEnd {
-    text-align: end;
-  }
-
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
-
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
+export function parseSidebarVariant(variant: unknown): SidebarVariant {
+  const result = sidebarVariantSchema.safeParse(variant);
+  return result.success ? result.data : SidebarVariantEnum.TOGGLE_IN_HEADER;
 }

--- a/apps/beeai-ui/src/modules/sidebar/schema.ts
+++ b/apps/beeai-ui/src/modules/sidebar/schema.ts
@@ -14,30 +14,13 @@
  * limitations under the License.
  */
 
-.root {
-  position: sticky;
-  inset-block-start: 0;
-  background-color: $background;
-  border-block-end: 1px solid $border-subtle-00;
-  z-index: 1;
-}
+import { z } from 'zod';
 
-.holder {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  column-gap: $gap;
-  align-items: center;
-  block-size: rem(56px);
-  .alignEnd {
-    text-align: end;
-  }
+export const SidebarVariantEnum = {
+  TOGGLE_IN_HEADER: 'toggle-in-header',
+  TOGGLE_BELOW_HEADER: 'toggle-below-header',
+};
 
-  &.hasNav {
-    grid-template-columns: auto 1fr;
-  }
-}
+export const sidebarVariantSchema = z.nativeEnum(SidebarVariantEnum);
 
-.agentName {
-  font-size: rem(14px);
-  line-height: math.div(20, 14);
-}
+export type SidebarVariant = z.infer<typeof sidebarVariantSchema>;

--- a/apps/beeai-ui/src/utils/vite-constants.ts
+++ b/apps/beeai-ui/src/utils/vite-constants.ts
@@ -23,3 +23,5 @@ export const NAV = parseNav(__NAV__);
 export const PHOENIX_SERVER_TARGET = __PHOENIX_SERVER_TARGET__;
 
 export const PROD_MODE = import.meta.env.PROD;
+
+export const SIDEBAR_VARIANT = __SIDEBAR_VARIANT__;

--- a/apps/beeai-ui/src/vite-env.d.ts
+++ b/apps/beeai-ui/src/vite-env.d.ts
@@ -20,3 +20,4 @@
 declare const __APP_NAME__: string;
 declare const __NAV__: object;
 declare const __PHOENIX_SERVER_TARGET__: string;
+declare const __SIDEBAR_VARIANT__: string;

--- a/apps/beeai-ui/vite.config.ts
+++ b/apps/beeai-ui/vite.config.ts
@@ -6,11 +6,12 @@ import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 import { loadFile } from './src/utils/files/loadFile';
+import { SidebarVariantEnum } from '#modules/sidebar/schema.ts';
 
 const DEFAULT_ENV = {
   VITE_APP_NAME: 'BeeAI',
   VITE_APP_FAVICON_SVG: '/bee.svg',
-  VITE_APP_SIDEBAR_VARIANT: 'toggle-in-header',
+  VITE_APP_SIDEBAR_VARIANT: SidebarVariantEnum.TOGGLE_IN_HEADER,
   VITE_API_SERVER_TARGET: 'http://localhost:8333',
   VITE_PHOENIX_SERVER_TARGET: 'http://localhost:6006',
 } as const;

--- a/apps/beeai-ui/vite.config.ts
+++ b/apps/beeai-ui/vite.config.ts
@@ -10,12 +10,13 @@ import { loadFile } from './src/utils/files/loadFile';
 const DEFAULT_ENV = {
   VITE_APP_NAME: 'BeeAI',
   VITE_APP_FAVICON_SVG: '/bee.svg',
+  VITE_APP_SIDEBAR_VARIANT: 'toggle-in-header',
   VITE_API_SERVER_TARGET: 'http://localhost:8333',
   VITE_PHOENIX_SERVER_TARGET: 'http://localhost:6006',
 } as const;
 
 export default defineConfig(async ({ mode }): Promise<UserConfig> => {
-  const { VITE_APP_NAME, VITE_APP_FAVICON_SVG, VITE_API_SERVER_TARGET, VITE_PHOENIX_SERVER_TARGET } = {
+  const { VITE_APP_NAME, VITE_APP_FAVICON_SVG, VITE_APP_SIDEBAR_VARIANT, VITE_API_SERVER_TARGET, VITE_PHOENIX_SERVER_TARGET } = {
     ...DEFAULT_ENV,
     ...loadEnv(mode, process.cwd()),
   };
@@ -37,6 +38,7 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
       __APP_NAME__: JSON.stringify(VITE_APP_NAME),
       __NAV__: await loadFile(import.meta.url, 'nav.json'),
       __PHOENIX_SERVER_TARGET__: JSON.stringify(VITE_PHOENIX_SERVER_TARGET),
+      __SIDEBAR_VARIANT__: JSON.stringify(VITE_APP_SIDEBAR_VARIANT),
     },
     server: {
       proxy: {


### PR DESCRIPTION
### Fixes
- fixed agent nav's title aligned to the end on Settings page (/components/AppHeader/AppHeader.module.scss)

### Updates
- added sidebar variant env variable and description to the README
- added toggle-below-header sidebar. Will share the design in a separate channel.

### Notes to the reviewers
- To view the new variant, add `VITE_APP_SIDEBAR_VARIANT=toggle-below-header` to `.env`
- For `toggle-below-header`, I moved the agent nav control into the `AgentHeader`, which I think is not an ideal solution. The main reason is the position of the "New Session" button: which now is relative to the length of the agent name. I felt this approach is cleaner than others, but I'm open to suggestions.
- The nav is always in the header on Settings page.