### PR TITLE
docs(contributing): fix anchor link in section reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Build image and run the platform using:
 mise run beeai-server:image:build
 mise run beeai-cli:run -- platform start --import ghcr.io/i-am-bee/beeai-platform/beeai-server:local --set image.tag=local
 ```
-Or use development setup described in [Running and debugging individual components](#Running and debugging individual components)
+Or use development setup described in [Running and debugging individual components](#running-and-debugging-individual-components)
 
 #### CLI
 


### PR DESCRIPTION
Fixes a broken Markdown anchor link in `CONTRIBUTING.md`.

The original link used spaces and capitalization, which prevented it from correctly linking to the "Running and debugging individual components" section. This update uses a GitHub-compatible anchor format.