### PR TITLE
fix(ui): minor chat bugs and improvs

### DIFF
--- a/apps/beeai-ui/src/modules/runs/chat/Message.tsx
+++ b/apps/beeai-ui/src/modules/runs/chat/Message.tsx
@@ -46,15 +46,18 @@ export function Message({ message }: Props) {
       <div className={classes.body}>
         {isPending ? (
           <Spinner />
-        ) : isError ? (
-          <ErrorMessage
-            title={isFailed ? 'Failed to generate an assistant message.' : 'Message generation has been cancelled.'}
-            subtitle={getErrorMessage(error)}
-          />
         ) : (
-          <div className={clsx(classes.content, { [classes.isUser]: isUser })}>
-            <MessageContent message={message} />
-          </div>
+          <>
+            <div className={clsx(classes.content, { [classes.isUser]: isUser })}>
+              <MessageContent message={message} />
+            </div>
+            {isError && (
+              <ErrorMessage
+                title={isFailed ? 'Failed to generate an agent message.' : 'Message generation has been cancelled.'}
+                subtitle={getErrorMessage(error)}
+              />
+            )}
+          </>
         )}
 
         <MessageFiles message={message} className={classes.files} />

--- a/apps/beeai-ui/src/modules/runs/contexts/agent-run/AgentRunProvider.tsx
+++ b/apps/beeai-ui/src/modules/runs/contexts/agent-run/AgentRunProvider.tsx
@@ -67,8 +67,8 @@ export function AgentRunProvider({ agent, children }: PropsWithChildren<Props>) 
 
       const isArtifact = isArtifactPart(part);
       const hasFile = isString(content_url);
-      const hasContent = isString(content);
       const hasImage = hasFile && isImageContentType(content_type);
+      const hasContentToDisplay = isString(content) && (content_type === 'text/plain' || hasImage);
 
       if (isArtifact) {
         if (hasFile) {
@@ -78,7 +78,7 @@ export function AgentRunProvider({ agent, children }: PropsWithChildren<Props>) 
         }
       }
 
-      if (hasContent) {
+      if (hasContentToDisplay) {
         updateLastAgentMessage((message) => {
           message.rawContent += content;
         });

--- a/apps/beeai-ui/src/modules/runs/contexts/agent-run/AgentRunProvider.tsx
+++ b/apps/beeai-ui/src/modules/runs/contexts/agent-run/AgentRunProvider.tsx
@@ -118,6 +118,13 @@ export function AgentRunProvider({ agent, children }: PropsWithChildren<Props>) 
         message.status = MessageStatus.Completed;
       });
     },
+    onRunCompleted: () => {
+      updateLastAgentMessage((message) => {
+        if (message.status !== MessageStatus.Completed) {
+          message.status = MessageStatus.Failed;
+        }
+      });
+    },
     onStop: () => {
       updateLastAgentMessage((message) => {
         message.status = MessageStatus.Aborted;

--- a/apps/beeai-ui/src/modules/runs/files/components/FileCard.module.scss
+++ b/apps/beeai-ui/src/modules/runs/files/components/FileCard.module.scss
@@ -5,6 +5,7 @@
 
 .root {
   display: inline-flex;
+  overflow: hidden;
   max-inline-size: 100%;
   align-items: center;
   position: relative;
@@ -46,7 +47,7 @@
 
 .link {
   @include link-mask();
-  text-decoration: none;
+  @include line-clamp();
   color: inherit;
   &::before {
     z-index: -1;

--- a/apps/beeai-ui/src/modules/runs/utils.ts
+++ b/apps/beeai-ui/src/modules/runs/utils.ts
@@ -48,19 +48,24 @@ export function createMessagePart({
   content_encoding = 'plain',
   content_type = 'text/plain',
   content_url,
+  name,
 }: Partial<Exclude<MessagePart, 'role'>>): MessagePart {
   return {
     content,
     content_encoding,
     content_type,
     content_url,
+    name,
     role: Role.User,
   };
 }
 
 export function createFileMessageParts(files: UploadFileResponse[]) {
-  const messageParts = files.map(({ id }) =>
-    createMessagePart({ content_url: getFileContentUrl({ id, addBase: true }) }),
+  const messageParts = files.map(({ id, filename }) =>
+    createMessagePart({
+      content_url: getFileContentUrl({ id, addBase: true }),
+      name: filename,
+    }),
   );
 
   return messageParts;


### PR DESCRIPTION
Closes #886 

This PR addresses:
- Long filenames in chat messages are now properly truncated.
- Only `content` with `content_type` of "text/plain "or "image/*" is added to the message content.
- If a message fails, any previously successful message parts remain visible.
- The filename of the uploaded file is now sent in the `name` field of the MessagePart.
- If no message is returned from the agent and the run completes, a “Failed” status is shown.

Also resolves #760:
- If no agent with supported UI is found on the platform, we now explicitly display a message instead of showing an infinite spinner.







