### PR TITLE
feat(ui): update nav items

### DIFF
--- a/apps/beeai-ui/.env.example
+++ b/apps/beeai-ui/.env.example
@@ -11,6 +11,7 @@ NEXT_PUBLIC_APP_FAVICON_SVG=
 # Default: 'http://localhost:6006'
 NEXT_PUBLIC_PHOENIX_SERVER_TARGET='http://localhost:6006'
 
-# Custom navigation structure in JSON format 
-# See ./src/modules/nav/schema.ts for the schema definition
+# Custom navigation (header, sidebar) in JSON format
+# Schema: ./src/modules/nav/schema.ts
+# Default: undefined
 NEXT_PUBLIC_NAV_ITEMS=

--- a/apps/beeai-ui/README.md
+++ b/apps/beeai-ui/README.md
@@ -1,33 +1,43 @@
 # BeeAI UI
 
+## ENV
+
+See [`.env.example`](./.env.example).
+
 ## Custom navigation
 
-By default, the header displays the agent's name and a detail button.
+By default:
 
-You can override this with a custom navigation.
-To do so, add a `nav.json` file to the root of the project.
-Example:
+- The **header** displays the **current agent's name** and a detail button.
+- The **sidebar** displays the list of **agents**.
+
+You can override this by providing a custom navigation.
+To do so, set `NEXT_PUBLIC_NAV_ITEMS` as a JSON-stringified value.
+
+Example (before stringification):
 
 ```json
 [
   {
     "label": "Playground",
     "url": "/",
-    "isActive": true
+    "activePathnames": ["/", "/agents"]
   },
   {
     "label": "Cookbooks",
-    "url": "https://example.com/cookbooks",
-    "isExternal": true
+    "url": "/docs/cookbooks",
+    "isExternal": true,
+    "target": "_self"
   },
   {
     "label": "Docs",
-    "url": "https://example.com/docs",
-    "isExternal": true
+    "url": "/docs",
+    "isExternal": true,
+    "target": "_self"
   },
   {
     "label": "Download Granite",
-    "url": "https://example.com/download-granite",
+    "url": "https://huggingface.co/ibm-granite/granite-3.3-8b-instruct",
     "isExternal": true,
     "position": "end"
   }
@@ -35,7 +45,3 @@ Example:
 ```
 
 For more details, see the [schema](./src/modules/nav/schema.ts).
-
-## ENV
-
-See [`.env.example`](./.env.example).

--- a/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.module.scss
@@ -13,13 +13,23 @@
   @include type-style(body-compact-01);
 
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
+
+  @include breakpoint-up(md) {
+    justify-content: space-between;
+  }
 }
 
 .ul {
   display: flex;
   column-gap: rem(40px);
+
+  &.start {
+    @include breakpoint-down(md) {
+      display: none;
+    }
+  }
 }
 
 .link {

--- a/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppHeaderNav.tsx
@@ -5,8 +5,11 @@
 
 import { ArrowUpRight } from '@carbon/icons-react';
 import clsx from 'clsx';
+import { usePathname } from 'next/navigation';
 
 import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
+import { groupNavItems } from '#modules/nav/groupNavItems.ts';
+import { isActive } from '#modules/nav/isActive.ts';
 import type { NavItem } from '#modules/nav/schema.ts';
 
 import classes from './AppHeaderNav.module.scss';
@@ -16,21 +19,19 @@ interface Props {
 }
 
 export function AppHeaderNav({ items }: Props) {
-  const groups = {
-    start: items.filter((item) => item.position !== 'end'),
-    end: items.filter((item) => item.position === 'end'),
-  };
+  const pathname = usePathname();
+  const groups = groupNavItems(items);
 
   return (
     <nav className={classes.nav}>
       {Object.entries(groups).map(([groupKey, group]) => (
-        <ul key={groupKey} className={classes.ul}>
-          {group.map(({ label, url, isExternal, isActive }) => (
-            <li key={label}>
-              {isExternal ? (
-                <ExternalLink label={label} url={url} />
+        <ul key={groupKey} className={clsx(classes.ul, classes[groupKey])}>
+          {group.map((item) => (
+            <li key={item.label}>
+              {item.isExternal ? (
+                <ExternalLink {...item} />
               ) : (
-                <InternalLink label={label} url={url} isActive={isActive} />
+                <InternalLink {...item} isActive={isActive(item, pathname ?? '')} />
               )}
             </li>
           ))}
@@ -40,20 +41,14 @@ export function AppHeaderNav({ items }: Props) {
   );
 }
 
-interface LinkProps {
-  label: string;
-  url: string;
-  isActive?: boolean;
-}
-
-const ExternalLink = ({ label, url }: LinkProps) => (
-  <a href={url} className={classes.link} target="_blank" rel="noreferrer">
+const ExternalLink = ({ label, url, target = '_blank' }: NavItem) => (
+  <a href={url} className={classes.link} target={target} rel="noreferrer">
     {label}
     <ArrowUpRight className={classes.icon} />
   </a>
 );
 
-const InternalLink = ({ label, url, isActive }: LinkProps) => (
+const InternalLink = ({ label, url, isActive }: NavItem & { isActive?: boolean }) => (
   <TransitionLink href={url} className={clsx(classes.link, { [classes.active]: isActive })}>
     {label}
   </TransitionLink>

--- a/apps/beeai-ui/src/components/AppHeader/AppName.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/AppName.module.scss
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.appName {
+  font-size: rem(14px);
+  line-height: math.div(18, 14);
+  font-weight: 600;
+  color: $text-dark;
+}

--- a/apps/beeai-ui/src/components/AppHeader/AppName.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/AppName.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { APP_NAME } from '#utils/constants.ts';
+
+import classes from './AppName.module.scss';
+
+export function AppName() {
+  return <span className={classes.appName}>{APP_NAME}</span>;
+}

--- a/apps/beeai-ui/src/components/AppHeader/SidebarButton.module.scss
+++ b/apps/beeai-ui/src/components/AppHeader/SidebarButton.module.scss
@@ -8,15 +8,20 @@
   align-items: center;
   column-gap: $spacing-03;
   margin-inline-start: -$spacing-03;
+
+  &.hasNav {
+    @include breakpoint-up(md) {
+      margin-inline-start: 0;
+    }
+  }
 }
 
 .button {
   @include hide-popover();
-}
 
-.label {
-  font-size: rem(14px);
-  line-height: math.div(18, 14);
-  font-weight: 600;
-  color: $text-dark;
+  .hasNav & {
+    @include breakpoint-up(md) {
+      display: none;
+    }
+  }
 }

--- a/apps/beeai-ui/src/components/AppHeader/SidebarButton.tsx
+++ b/apps/beeai-ui/src/components/AppHeader/SidebarButton.tsx
@@ -5,17 +5,19 @@
 
 import { Menu } from '@carbon/icons-react';
 import { IconButton } from '@carbon/react';
+import clsx from 'clsx';
 
 import { useApp } from '#contexts/App/index.ts';
-import { APP_NAME } from '#utils/constants.ts';
+import { NAV_ITEMS } from '#utils/constants.ts';
 
+import { AppName } from './AppName';
 import classes from './SidebarButton.module.scss';
 
 export function SidebarButton() {
   const { setNavigationOpen } = useApp();
 
   return (
-    <div className={classes.root}>
+    <div className={clsx(classes.root, { [classes.hasNav]: NAV_ITEMS.length > 0 })}>
       <IconButton
         kind="ghost"
         size="sm"
@@ -27,7 +29,7 @@ export function SidebarButton() {
         <Menu />
       </IconButton>
 
-      <span className={classes.label}>{APP_NAME}</span>
+      <AppName />
     </div>
   );
 }

--- a/apps/beeai-ui/src/components/CustomNav/CustomNav.tsx
+++ b/apps/beeai-ui/src/components/CustomNav/CustomNav.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import { Nav, type NavItem as SideNavItem } from '#components/SidePanel/Nav.tsx';
+import { groupNavItems } from '#modules/nav/groupNavItems.ts';
+import { isActive } from '#modules/nav/isActive.ts';
+import type { NavItem } from '#modules/nav/schema.ts';
+
+interface Props {
+  items: NavItem[];
+}
+
+export function CustomNav({ items }: Props) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { start } = groupNavItems(items);
+  const theItems: SideNavItem[] = start.map((item) => ({
+    ...item,
+    key: item.url,
+    isActive: isActive(item, pathname ?? ''),
+    onClick() {
+      if (item.isExternal) {
+        window.open(item.url, '_blank', 'noopener,noreferrer');
+      } else {
+        router.push(item.url);
+      }
+    },
+  }));
+
+  return <Nav items={theItems} />;
+}

--- a/apps/beeai-ui/src/components/CustomNav/CustomNav.tsx
+++ b/apps/beeai-ui/src/components/CustomNav/CustomNav.tsx
@@ -24,7 +24,7 @@ export function CustomNav({ items }: Props) {
     isActive: isActive(item, pathname ?? ''),
     onClick() {
       if (item.isExternal) {
-        window.open(item.url, '_blank', 'noopener,noreferrer');
+        window.open(item.url, item.target ?? '_blank', 'noopener,noreferrer');
       } else {
         router.push(item.url);
       }

--- a/apps/beeai-ui/src/components/SidePanel/Nav.module.scss
+++ b/apps/beeai-ui/src/components/SidePanel/Nav.module.scss
@@ -40,7 +40,7 @@
   row-gap: $spacing-02;
 }
 
-.button {
+.button:global(.cds--btn) {
   @include reset-focus();
   justify-content: flex-start;
   align-items: center;

--- a/apps/beeai-ui/src/components/SidePanel/SidePanel.module.scss
+++ b/apps/beeai-ui/src/components/SidePanel/SidePanel.module.scss
@@ -36,6 +36,12 @@ $rightPanelWidth: rem(432px);
   &:not(.isOpen) {
     transition-timing-function: motion(entrance, expressive);
   }
+
+  &.hasNav {
+    @include breakpoint-up(md) {
+      display: none;
+    }
+  }
 }
 
 .content {

--- a/apps/beeai-ui/src/components/SidePanel/SidePanel.tsx
+++ b/apps/beeai-ui/src/components/SidePanel/SidePanel.tsx
@@ -6,6 +6,8 @@
 import clsx from 'clsx';
 import { forwardRef, type PropsWithChildren } from 'react';
 
+import { NAV_ITEMS } from '#utils/constants.ts';
+
 import classes from './SidePanel.module.scss';
 
 interface Props {
@@ -26,6 +28,7 @@ export const SidePanel = forwardRef<HTMLElement, PropsWithChildren<Props>>(funct
         [classes[variant]],
         {
           [classes.isOpen]: isOpen,
+          [classes.hasNav]: NAV_ITEMS.length > 0,
         },
         className,
       )}

--- a/apps/beeai-ui/src/components/layouts/MainNav.tsx
+++ b/apps/beeai-ui/src/components/layouts/MainNav.tsx
@@ -3,28 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type RefObject, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { type RefObject, useEffect, useRef } from 'react';
 import { useOnClickOutside } from 'usehooks-ts';
 
 import { AgentsNav } from '#components/AgentsNav/AgentsNav.tsx';
 import { SidebarButton } from '#components/AppHeader/SidebarButton.tsx';
+import { CustomNav } from '#components/CustomNav/CustomNav.tsx';
 import { SidePanel } from '#components/SidePanel/SidePanel.tsx';
 import { UserNav } from '#components/UserNav/UserNav.tsx';
 import { useApp } from '#contexts/App/index.ts';
 import { useAppConfig } from '#contexts/AppConfig/index.ts';
+import { NAV_ITEMS } from '#utils/constants.ts';
 
 import classes from './MainNav.module.scss';
 
 export function MainNav() {
+  const pathname = usePathname();
   const { navigationOpen, closeNavOnClickOutside, setNavigationOpen } = useApp();
   const { featureFlags } = useAppConfig();
   const navRef = useRef<HTMLDivElement>(null);
+  const hasNav = NAV_ITEMS.length > 0;
 
   useOnClickOutside(navRef as RefObject<HTMLDivElement>, () => {
-    if (closeNavOnClickOutside) {
+    if (closeNavOnClickOutside || hasNav) {
       setNavigationOpen(false);
     }
   });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: OK
+  useEffect(() => {
+    if (hasNav) {
+      setNavigationOpen(false);
+    }
+  }, [setNavigationOpen, pathname]);
 
   return (
     <div ref={navRef}>
@@ -32,7 +44,7 @@ export function MainNav() {
 
       <SidePanel variant="left" isOpen={navigationOpen}>
         <div className={classes.root}>
-          <AgentsNav />
+          {hasNav ? <CustomNav items={NAV_ITEMS} /> : <AgentsNav />}
 
           {featureFlags?.user_navigation && (
             <div className={classes.footer}>

--- a/apps/beeai-ui/src/components/layouts/MainNav.tsx
+++ b/apps/beeai-ui/src/components/layouts/MainNav.tsx
@@ -18,21 +18,23 @@ import { NAV_ITEMS } from '#utils/constants.ts';
 
 import classes from './MainNav.module.scss';
 
+type NavVariant = 'custom' | 'agents';
+
 export function MainNav() {
   const pathname = usePathname();
   const { navigationOpen, closeNavOnClickOutside, setNavigationOpen } = useApp();
   const { featureFlags } = useAppConfig();
   const navRef = useRef<HTMLDivElement>(null);
-  const hasNav = NAV_ITEMS.length > 0;
+  const navVariant: NavVariant = NAV_ITEMS.length ? 'custom' : 'agents';
 
   useOnClickOutside(navRef as RefObject<HTMLDivElement>, () => {
-    if (closeNavOnClickOutside || hasNav) {
+    if (closeNavOnClickOutside || navVariant === 'custom') {
       setNavigationOpen(false);
     }
   });
 
   useEffect(() => {
-    if (hasNav) {
+    if (navVariant === 'custom') {
       setNavigationOpen(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -44,7 +46,8 @@ export function MainNav() {
 
       <SidePanel variant="left" isOpen={navigationOpen}>
         <div className={classes.root}>
-          {hasNav ? <CustomNav items={NAV_ITEMS} /> : <AgentsNav />}
+          {navVariant === 'custom' && <CustomNav items={NAV_ITEMS} />}
+          {navVariant === 'agents' && <AgentsNav />}
 
           {featureFlags?.user_navigation && (
             <div className={classes.footer}>

--- a/apps/beeai-ui/src/components/layouts/MainNav.tsx
+++ b/apps/beeai-ui/src/components/layouts/MainNav.tsx
@@ -36,6 +36,7 @@ export function MainNav() {
     if (hasNav) {
       setNavigationOpen(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setNavigationOpen, pathname]);
 
   return (

--- a/apps/beeai-ui/src/components/layouts/MainNav.tsx
+++ b/apps/beeai-ui/src/components/layouts/MainNav.tsx
@@ -31,7 +31,6 @@ export function MainNav() {
     }
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: OK
   useEffect(() => {
     if (hasNav) {
       setNavigationOpen(false);

--- a/apps/beeai-ui/src/modules/nav/groupNavItems.ts
+++ b/apps/beeai-ui/src/modules/nav/groupNavItems.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NavItem } from './schema';
+
+type Groups = {
+  start: NavItem[];
+  end: NavItem[];
+};
+
+export function groupNavItems(items: NavItem[]): Groups {
+  return {
+    start: items.filter((item) => item.position !== 'end'),
+    end: items.filter((item) => item.position === 'end'),
+  };
+}

--- a/apps/beeai-ui/src/modules/nav/isActive.ts
+++ b/apps/beeai-ui/src/modules/nav/isActive.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NavItem } from './schema';
+
+export function isActive(item: NavItem, pathname: string): boolean {
+  return (item.activePathnames ?? []).some((active) => pathname === active || pathname.startsWith(`${active}/`));
+}

--- a/apps/beeai-ui/src/modules/nav/parseNav.ts
+++ b/apps/beeai-ui/src/modules/nav/parseNav.ts
@@ -5,7 +5,15 @@
 
 import { type NavItem, navSchema } from './schema';
 
-export function parseNav(data: unknown): NavItem[] {
-  const result = navSchema.safeParse(data);
-  return result.success ? result.data : [];
+export function parseNav(data: string | undefined): NavItem[] {
+  if (!data) {
+    return [];
+  }
+
+  try {
+    const json = JSON.parse(data);
+    return navSchema.parse(json);
+  } catch {
+    return [];
+  }
 }

--- a/apps/beeai-ui/src/modules/nav/schema.ts
+++ b/apps/beeai-ui/src/modules/nav/schema.ts
@@ -7,9 +7,10 @@ import { z } from 'zod';
 
 const navItemSchema = z.object({
   label: z.string(),
-  url: z.union([z.string().url(), z.literal('/')]),
-  isActive: z.boolean().optional(),
+  url: z.string(),
+  activePathnames: z.array(z.string()).optional(),
   isExternal: z.boolean().optional(),
+  target: z.enum(['_self', '_blank']).optional(),
   position: z.enum(['start', 'end']).optional(),
 });
 


### PR DESCRIPTION
**ONLY** if having `NAV_ITEMS`:

- _Show_ **"start"** items in `<MainNav>`
- _Show_ **"start"** items in `<AppHeaderNav>` on `md+` only
- _Show_ `<SidebarButton>` on `<md` only
- _Auto-close_ `<MainNav>`

Also related to `NAV_ITEMS`:

- Update schema for nav items (`.activePathnames`, `.target`)
- Add helpers: `groupNavItems()`, `isActive()`
- Fix **parsing** in `parseNav()`

Other changes:

- Move app name to `<AppName>`

---

### ENV

For a quick test, use:

```
NEXT_PUBLIC_NAV_ITEMS='[{"label":"Playground","url":"/","activePathnames":["/","/agents"]},{"label":"Cookbooks","url":"/docs/cookbooks","isExternal":true,"target":"_self"},{"label":"Docs","url":"/docs","isExternal":true,"target":"_self"},{"label":"Download Granite","url":"https://huggingface.co/ibm-granite/granite-3.3-8b-instruct","isExternal":true,"position":"end"}]'
```

---

<br>

### PREVIEW (Desktop)

<img width="2684" height="1966" alt="desktop" src="https://github.com/user-attachments/assets/3f6a36b8-afb6-4ec6-b65f-49eae52d3860" />

<br>

### PREVIEW (Mobile)

<img width="996" height="1966" alt="mobile" src="https://github.com/user-attachments/assets/3ca88142-a72f-412a-9fa4-c8fd134d371d" />
