### PR TITLE
feat(ui): support custom basePath

### DIFF
--- a/apps/beeai-ui/.env.example
+++ b/apps/beeai-ui/.env.example
@@ -1,6 +1,10 @@
-API_URL='http://127.0.0.1:8333'
-
 ############# OPTIONAL #############
+
+# Default: 'http://127.0.0.1:8333'
+API_URL=
+
+# Default: ''
+NEXT_PUBLIC_BASE_PATH=
 
 # Default: 'BeeAI'
 NEXT_PUBLIC_APP_NAME=
@@ -9,7 +13,7 @@ NEXT_PUBLIC_APP_NAME=
 NEXT_PUBLIC_APP_FAVICON_SVG=
 
 # Default: 'http://localhost:31606'
-NEXT_PUBLIC_PHOENIX_SERVER_TARGET='http://localhost:31606'
+NEXT_PUBLIC_PHOENIX_SERVER_TARGET=
 
 # Custom navigation (header, sidebar) in JSON format
 # Schema: ./src/modules/nav/schema.ts

--- a/apps/beeai-ui/next.config.ts
+++ b/apps/beeai-ui/next.config.ts
@@ -8,6 +8,7 @@ import path from 'path';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   sassOptions: {
     additionalData: `@use 'styles/common' as *; @use 'sass:math';`,
     // silenceDeprecations: ['mixed-decls', 'global-builtin'],

--- a/apps/beeai-ui/src/acp/index.ts
+++ b/apps/beeai-ui/src/acp/index.ts
@@ -5,8 +5,8 @@
 
 import { Client } from 'acp-sdk';
 
-import { API_URL } from '#utils/constants.ts';
+import { getBaseUrl } from '#utils/api/getBaseUrl.ts';
 
 export const acp = new Client({
-  baseUrl: `${API_URL ?? ''}/api/v1/acp/`,
+  baseUrl: getBaseUrl('/api/v1/acp/'),
 });

--- a/apps/beeai-ui/src/api/index.ts
+++ b/apps/beeai-ui/src/api/index.ts
@@ -5,10 +5,10 @@
 
 import createClient from 'openapi-fetch';
 
-import { API_URL } from '#utils/constants.ts';
+import { getBaseUrl } from '#utils/api/getBaseUrl.ts';
 
 import type { paths } from './schema';
 
 export const api = createClient<paths>({
-  baseUrl: API_URL,
+  baseUrl: getBaseUrl(),
 });

--- a/apps/beeai-ui/src/app/api/[...path]/route.ts
+++ b/apps/beeai-ui/src/app/api/[...path]/route.ts
@@ -5,6 +5,8 @@
 
 import type { NextRequest } from 'next/server';
 
+import { API_URL } from '#utils/constants.ts';
+
 type RouteContext = {
   params: Promise<{
     path: string[];
@@ -16,7 +18,7 @@ async function handler(request: NextRequest, context: RouteContext) {
   const { path } = await context.params;
   const search = nextUrl.search;
 
-  const url = new URL(process.env.API_URL!);
+  const url = new URL(API_URL);
   const targetUrl = `${url}api/${path.join('/')}${search}`;
 
   const res = await fetch(targetUrl, {

--- a/apps/beeai-ui/src/app/layout.tsx
+++ b/apps/beeai-ui/src/app/layout.tsx
@@ -8,7 +8,7 @@ import '../styles/style.scss';
 import type { Metadata } from 'next';
 
 import { AppLayout } from '#components/layouts/AppLayout.tsx';
-import { APP_FAVICON_SVG, APP_NAME } from '#utils/constants.ts';
+import { APP_FAVICON_SVG, APP_NAME, BASE_PATH } from '#utils/constants.ts';
 
 import Providers from './providers';
 
@@ -31,11 +31,13 @@ const darkModeScript = `
 })();
 `;
 
+const icon = `${BASE_PATH}${APP_FAVICON_SVG}`;
+
 export const metadata: Metadata = {
   title: APP_NAME,
   icons: {
-    icon: APP_FAVICON_SVG,
-    shortcut: APP_FAVICON_SVG,
+    icon: icon,
+    shortcut: icon,
   },
 };
 

--- a/apps/beeai-ui/src/utils/api/getBaseUrl.ts
+++ b/apps/beeai-ui/src/utils/api/getBaseUrl.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { API_URL, BASE_PATH } from '#utils/constants.ts';
+
+export function getBaseUrl(suffix = '') {
+  const baseUrl = typeof window !== 'undefined' ? BASE_PATH : API_URL;
+  return baseUrl + suffix;
+}

--- a/apps/beeai-ui/src/utils/constants.ts
+++ b/apps/beeai-ui/src/utils/constants.ts
@@ -5,6 +5,8 @@
 
 import { parseNav } from '#modules/nav/parseNav.ts';
 
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME ?? 'BeeAI';
 
 export const APP_FAVICON_SVG = process.env.NEXT_PUBLIC_APP_FAVICON_SVG ?? '/bee.svg';
@@ -13,7 +15,7 @@ export const PHOENIX_SERVER_TARGET = process.env.NEXT_PUBLIC_PHOENIX_SERVER_TARG
 
 export const NAV_ITEMS = parseNav(process.env.NEXT_PUBLIC_NAV_ITEMS);
 
-export const API_URL = process.env.API_URL;
+export const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8333';
 
 export const PROD_MODE = process.env.NODE_ENV === 'production';
 


### PR DESCRIPTION
Support **custom** `basePath`.

Ensure the **correct** _API URL_ is constructed when called from either the **server** or the **client**.

<br>

### How to test (development)

1. Set:

```
NEXT_PUBLIC_BASE_PATH='/granite/playground'
```

<br>

2. Run:

```
$ mise beeai-ui:run:dev
```

<br>

3. Open: http://localhost:3000/granite/playground

<br>

---

<br>

### How to test (build)

1. Set:

```
NEXT_PUBLIC_BASE_PATH='/granite/playground'
```

<br>

2. Run:

```
$ mise beeai-ui:build:nextjs
$ mise beeai-ui:run
```

<br>

3. Open: http://localhost:3000/granite/playground

<br><br><br>

### Expectations

- API calls use the correct base path and work (both "ACP" and "API").
- Favicon correctly set.