### PR TITLE
fix(ui): new session button position

### DIFF
--- a/apps/beeai-ui/src/modules/runs/chat/ChatAgentMessage.module.scss
+++ b/apps/beeai-ui/src/modules/runs/chat/ChatAgentMessage.module.scss
@@ -16,7 +16,7 @@
     inset-block: -$spacing-05;
     inset-inline-start: 50%;
     transform: translateX(-50%);
-    background-color: $layer-hover-01;
+    background-color: $background-hover-50;
     z-index: -1;
     transition: opacity $duration-fast-02;
   }

--- a/apps/beeai-ui/src/modules/runs/chat/ChatMessagesView.module.scss
+++ b/apps/beeai-ui/src/modules/runs/chat/ChatMessagesView.module.scss
@@ -10,6 +10,9 @@ $messages-row-gap: $spacing-07;
 $holder-row-gap: $spacing-06;
 $input-height: rem(88px);
 
+$zindex-messages: 1;
+$zindex-buttons: 2;
+
 .holder {
   inline-size: 100%;
   display: grid;
@@ -26,11 +29,10 @@ $input-height: rem(88px);
 
 .header {
   position: sticky;
-  inset-block-start: 0;
+  inset-block-start: $spacing-03;
   text-align: end;
-  background-color: $layer;
   padding-block-end: $spacing-06;
-  z-index: 1;
+  z-index: $zindex-buttons;
 }
 
 .container {
@@ -42,6 +44,7 @@ $input-height: rem(88px);
   display: flex;
   flex-direction: column;
   row-gap: $messages-row-gap;
+  padding-block-start: $spacing-03;
   block-size: 100%;
 }
 
@@ -81,7 +84,7 @@ $input-height: rem(88px);
     inset-block-end: 100%;
     inset-inline-start: 50%;
     transform: translate(-50%, -$spacing-05);
-    z-index: 1;
+    z-index: $zindex-messages;
   }
 }
 

--- a/apps/beeai-ui/src/modules/runs/components/NewSessionButton.module.scss
+++ b/apps/beeai-ui/src/modules/runs/components/NewSessionButton.module.scss
@@ -1,0 +1,8 @@
+/**
+ * Copyright 2025 © BeeAI a Series of LF Projects, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.root {
+  background-color: $background;
+}

--- a/apps/beeai-ui/src/modules/runs/components/NewSessionButton.tsx
+++ b/apps/beeai-ui/src/modules/runs/components/NewSessionButton.tsx
@@ -7,6 +7,7 @@ import { IconButton } from '@carbon/react';
 import type { MouseEventHandler } from 'react';
 
 import NewSession from './NewSession.svg';
+import classes from './NewSessionButton.module.scss';
 
 interface Props {
   onClick: MouseEventHandler;
@@ -14,7 +15,15 @@ interface Props {
 
 export function NewSessionButton({ onClick }: Props) {
   return (
-    <IconButton kind="tertiary" size="sm" label="New session" align="bottom" autoAlign onClick={onClick}>
+    <IconButton
+      kind="tertiary"
+      size="sm"
+      label="New session"
+      align="bottom"
+      autoAlign
+      onClick={onClick}
+      className={classes.root}
+    >
       <NewSession />
     </IconButton>
   );


### PR DESCRIPTION
This PR includes:
- closes #1096
- Updated message hover color, so the code blocks don't blend with the background
- minor adjustment of New session button to prevent it from sticking to to the top padding, when underlying message is hovered