### PR TITLE
style: spinner getting cropped in small size fix

### DIFF
--- a/apps/beeai-ui/src/components/Spinner/Spinner.module.scss
+++ b/apps/beeai-ui/src/components/Spinner/Spinner.module.scss
@@ -20,6 +20,7 @@
       block-size: 2.8rem;
       min-inline-size: 2.8rem;
       transform: translate(0, 0.1rem);
+      padding: rem(1px);
     }
   }
 


### PR DESCRIPTION
### Updates

Added additional 1px padding to the animation container so the resized Lottie animation is not cropped in size `sm` due to its svg animation resizing glitch

Closes: #1132

Signed-off-by: jayolee <43683780+jayolee@users.noreply.github.com>