### PR TITLE
chore(sdk): Allow setting agent card interfaces

### DIFF
--- a/apps/beeai-sdk/src/beeai_sdk/server/agent.py
+++ b/apps/beeai-sdk/src/beeai_sdk/server/agent.py
@@ -53,6 +53,7 @@ def agent(
     name: str | None = None,
     description: str | None = None,
     *,
+    url: str = "http://invalid",  # Default will be replaced by the server
     additional_interfaces: list[AgentInterface] | None = None,
     capabilities: AgentCapabilities | None = None,
     default_input_modes: list[str] | None = None,
@@ -116,6 +117,8 @@ def agent(
         ]
 
         card = AgentCard(
+            url=url,
+            preferred_transport=preferred_transport,
             additional_interfaces=additional_interfaces,
             capabilities=capabilities,
             default_input_modes=default_input_modes or ["text"],
@@ -124,13 +127,11 @@ def agent(
             documentation_url=documentation_url,
             icon_url=icon_url,
             name=resolved_name,
-            preferred_transport=preferred_transport,
             provider=provider,
             security=security,
             security_schemes=security_schemes,
             skills=skills or [],
             supports_authenticated_extended_card=supports_authenticated_extended_card,
-            url="http://localhost:10000",  # dummy url - will be replaced by server
             version=version or "1.0.0",
         )
 

--- a/apps/beeai-sdk/src/beeai_sdk/server/app.py
+++ b/apps/beeai-sdk/src/beeai_sdk/server/app.py
@@ -25,6 +25,7 @@ def create_app(
     request_context_builder: RequestContextBuilder | None = None,
     lifespan: Lifespan[AppType] | None = None,
     dependencies: list[Depends] | None = None,  # pyright: ignore [reportGeneralTypeIssues]
+    override_interfaces: bool = True,
     **kwargs,
 ) -> FastAPI:
     queue_manager = queue_manager or InMemoryQueueManager()
@@ -38,12 +39,13 @@ def create_app(
         request_context_builder=request_context_builder,
     )
 
-    agent.card.additional_interfaces = [
-        AgentInterface(url=agent.card.url, transport=TransportProtocol.http_json),
-        AgentInterface(url=agent.card.url + "/jsonrpc/", transport=TransportProtocol.jsonrpc),
-    ]
-    agent.card.url = agent.card.url + "/jsonrpc/"
-    agent.card.preferred_transport = TransportProtocol.jsonrpc
+    if override_interfaces:
+        agent.card.additional_interfaces = [
+            AgentInterface(url=agent.card.url, transport=TransportProtocol.http_json),
+            AgentInterface(url=agent.card.url + "/jsonrpc/", transport=TransportProtocol.jsonrpc),
+        ]
+        agent.card.url = agent.card.url + "/jsonrpc/"
+        agent.card.preferred_transport = TransportProtocol.jsonrpc
 
     jsonrpc_app = A2AFastAPIApplication(agent_card=agent.card, http_handler=http_handler).build(
         dependencies=dependencies,

--- a/apps/beeai-sdk/src/beeai_sdk/server/server.py
+++ b/apps/beeai-sdk/src/beeai_sdk/server/server.py
@@ -22,6 +22,7 @@ from a2a.types import AgentExtension
 from fastapi import FastAPI
 from fastapi.applications import AppType
 from httpx import AsyncClient, HTTPError, HTTPStatusError
+from pydantic import AnyUrl
 from starlette.types import Lifespan
 from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_exponential
 
@@ -140,7 +141,9 @@ class Server:
                 if register_task:
                     await cancel_task(register_task)
 
-        self._agent.card.url = f"http://{host}:{port}"
+        card_url = AnyUrl(self._agent.card.url)
+        if card_url.host == "invalid":
+            self._agent.card.url = f"http://{host}:{port}"
 
         app = create_app(
             self._agent,


### PR DESCRIPTION
## Problem

URLs in the agent card must sometimes be different from the server's host+port to enable reverse proxies (cluster setting).

## Solution

We can't dynamically resolve this URL due to a limitation in A2A interface https://github.com/a2aproject/a2a-python/blob/b2e3a29607cdac9b555e7fd188048c67dd72dc67/src/a2a/server/apps/rest/fastapi_app.py#L52. Note that this limitation might be intended as the agent card should be mostly static.

Therefore we at least allow SDK users to setup the values in the agent card.