### PR TITLE
fix(ui): use patch instead of put for update context metadata

### DIFF
--- a/apps/beeai-ui/src/@types/utils.ts
+++ b/apps/beeai-ui/src/@types/utils.ts
@@ -31,7 +31,7 @@ export type ApiResponse<
 
 export type ApiRequest<
   Path extends keyof paths,
-  Method extends keyof paths[Path] & ('get' | 'post' | 'delete' | 'put') = 'post',
+  Method extends keyof paths[Path] & ('get' | 'post' | 'delete' | 'put' | 'patch') = 'post',
   ContentType extends 'application/json' | 'multipart/form-data' = 'application/json',
 > = paths[Path][Method] extends {
   requestBody?: {
@@ -63,7 +63,7 @@ export type ApiQuery<
 
 export type ApiPath<
   Path extends keyof paths,
-  Method extends keyof paths[Path] & ('get' | 'post' | 'put' | 'delete') = 'get',
+  Method extends keyof paths[Path] & ('get' | 'post' | 'put' | 'delete' | 'patch') = 'get',
 > = paths[Path][Method] extends {
   parameters: { path?: infer P };
 }

--- a/apps/beeai-ui/src/modules/platform-context/api/index.ts
+++ b/apps/beeai-ui/src/modules/platform-context/api/index.ts
@@ -13,7 +13,7 @@ import type {
   ListContextHistoryParams,
   ListContextsParams,
   MatchModelProvidersParams,
-  UpdateContextParams,
+  UpdateContextMetadataParams,
 } from './types';
 
 export async function createContext(body: CreateContextParams) {
@@ -28,8 +28,8 @@ export async function listContexts({ query }: ListContextsParams) {
   return ensureData(response);
 }
 
-export async function updateContext({ context_id, metadata }: UpdateContextParams) {
-  const response = await api.PUT('/api/v1/contexts/{context_id}', {
+export async function updateContextMetadata({ context_id, metadata }: UpdateContextMetadataParams) {
+  const response = await api.PATCH('/api/v1/contexts/{context_id}/metadata', {
     body: { metadata },
     params: { path: { context_id } },
   });

--- a/apps/beeai-ui/src/modules/platform-context/api/mutations/useUpdateContextMetadata.ts
+++ b/apps/beeai-ui/src/modules/platform-context/api/mutations/useUpdateContextMetadata.ts
@@ -5,12 +5,12 @@
 
 import { useMutation } from '@tanstack/react-query';
 
-import { updateContext } from '..';
+import { updateContextMetadata } from '..';
 import { contextKeys } from '../keys';
 
-export function useUpdateContext() {
+export function useUpdateContextMetadata() {
   const mutation = useMutation({
-    mutationFn: updateContext,
+    mutationFn: updateContextMetadata,
     meta: {
       invalidates: [contextKeys.lists()],
     },

--- a/apps/beeai-ui/src/modules/platform-context/api/types.ts
+++ b/apps/beeai-ui/src/modules/platform-context/api/types.ts
@@ -15,14 +15,14 @@ export type ListContextsQuery = ApiQuery<'/api/v1/contexts'>;
 export type ListContextsResponse = ApiResponse<'/api/v1/contexts'>;
 export type ListContextsParams = { query?: ListContextsQuery };
 
-export type UpdateContextPath = ApiPath<'/api/v1/contexts/{context_id}', 'put'>;
-export type UpdateContextRequest = ApiRequest<'/api/v1/contexts/{context_id}', 'put'> & {
-  metadata: Pick<ContextMetadata, 'agent_name' | 'provider_id'>;
-};
-export type UpdateContextParams = UpdateContextPath & UpdateContextRequest;
-
 export type DeleteContextPath = ApiPath<'/api/v1/contexts/{context_id}'>;
 export type DeleteContextParams = DeleteContextPath;
+
+export type UpdateContextMetadataPath = ApiPath<'/api/v1/contexts/{context_id}/metadata', 'patch'>;
+export type UpdateContextMetadataRequest = ApiRequest<'/api/v1/contexts/{context_id}/metadata', 'patch'> & {
+  metadata: Pick<ContextMetadata, 'agent_name' | 'provider_id'>;
+};
+export type UpdateContextMetadataParams = UpdateContextMetadataPath & UpdateContextMetadataRequest;
 
 export type ListContextHistoryQuery = ApiQuery<'/api/v1/contexts/{context_id}/history'>;
 export type ListContextHistoryResponse = ApiResponse<'/api/v1/contexts/{context_id}/history'>;

--- a/apps/beeai-ui/src/modules/platform-context/contexts/PlatformContextProvider.tsx
+++ b/apps/beeai-ui/src/modules/platform-context/contexts/PlatformContextProvider.tsx
@@ -9,7 +9,7 @@ import { useParamsFromUrl } from '#hooks/useParamsFromUrl.ts';
 import type { Agent } from '#modules/agents/api/types.ts';
 
 import { useCreateContext } from '../api/mutations/useCreateContext';
-import { useUpdateContext } from '../api/mutations/useUpdateContext';
+import { useUpdateContextMetadata } from '../api/mutations/useUpdateContextMetadata';
 import type { ListContextHistoryResponse } from '../api/types';
 import { PlatformContext } from './platform-context';
 
@@ -35,7 +35,7 @@ export function PlatformContextProvider({ history, children }: PropsWithChildren
     },
   });
 
-  const { mutateAsync: updateContext } = useUpdateContext();
+  const { mutateAsync: updateContextMetadata } = useUpdateContextMetadata();
 
   const resetContext = useCallback(() => {
     setContextId(null);
@@ -47,7 +47,7 @@ export function PlatformContextProvider({ history, children }: PropsWithChildren
         return;
       }
 
-      await updateContext({
+      await updateContextMetadata({
         context_id: contextId,
         metadata: {
           agent_name: agent.name ?? '',
@@ -55,7 +55,7 @@ export function PlatformContextProvider({ history, children }: PropsWithChildren
         },
       });
     },
-    [contextId, updateContext],
+    [contextId, updateContextMetadata],
   );
 
   const getContextId = useCallback(() => {

--- a/apps/beeai-ui/src/modules/platform-context/contexts/PlatformContextProvider.tsx
+++ b/apps/beeai-ui/src/modules/platform-context/contexts/PlatformContextProvider.tsx
@@ -50,8 +50,8 @@ export function PlatformContextProvider({ history, children }: PropsWithChildren
       await updateContextMetadata({
         context_id: contextId,
         metadata: {
-          agent_name: agent.name ?? '',
-          provider_id: agent.provider.id ?? '',
+          agent_name: agent.name,
+          provider_id: agent.provider.id,
         },
       });
     },


### PR DESCRIPTION
We need to use PATCH endpoint to update context metadata. The original PUT was replacing all stored values.